### PR TITLE
Fix bug in app-servive linked template

### DIFF
--- a/DevOps/linked-templates/app-service.json
+++ b/DevOps/linked-templates/app-service.json
@@ -54,6 +54,7 @@
   },
   "resources": [
     {
+      "properties": {},
       "type": "Microsoft.Web/serverfarms",
       "apiVersion": "2022-03-01",
       "name": "[parameters('appServicePlanName')]",


### PR DESCRIPTION
Properties in linked template caused issues as a none existence. Created an empty properties and bug was fixed.