### PR TITLE
Add feature to restrict access to school users

### DIFF
--- a/Dfe.SchoolAccount.SignIn.Tests/Extensions/ClaimExtensionsTests.cs
+++ b/Dfe.SchoolAccount.SignIn.Tests/Extensions/ClaimExtensionsTests.cs
@@ -49,15 +49,27 @@ public sealed class ClaimExtensionsTests
     }
 
     [TestMethod]
-    public void GetOrganisation_ThrowsInvalidOperationException_WhenPrincipalHasNoOrganisationClaim()
+    public void GetOrganisation_ReturnsNull_WhenPrincipalHasNoOrganisationClaim()
     {
         var principal = new ClaimsPrincipal();
 
-        var act = () => {
-            _ = ClaimExtensions.GetOrganisation(principal);
-        };
+        var organisation = ClaimExtensions.GetOrganisation(principal);
 
-        Assert.ThrowsException<InvalidOperationException>(act);
+        Assert.IsNull(organisation);
+    }
+
+    [TestMethod]
+    public void GetOrganisation_ReturnsNull_WhenPrincipalHasAnEmptyOrganisationClaim()
+    {
+        var claims = new List<Claim>() {
+            new Claim(ClaimConstants.Organisation, "{}"),
+        };
+        var identity = new ClaimsIdentity(claims);
+        var principal = new ClaimsPrincipal(identity);
+
+        var organisation = ClaimExtensions.GetOrganisation(principal);
+
+        Assert.IsNull(organisation);
     }
 
     [TestMethod]
@@ -86,7 +98,7 @@ public sealed class ClaimExtensionsTests
         var identity = new ClaimsIdentity(claims);
         var principal = new ClaimsPrincipal(identity);
 
-        var organisation = ClaimExtensions.GetOrganisation(principal);
+        var organisation = ClaimExtensions.GetOrganisation(principal)!;
             
         Assert.AreEqual(new Guid("00000000-0000-0000-0000-000000000001"), organisation.Id);
         Assert.AreEqual("An example organisation name", organisation.Name);

--- a/Dfe.SchoolAccount.SignIn/Extensions/ClaimExtensions.cs
+++ b/Dfe.SchoolAccount.SignIn/Extensions/ClaimExtensions.cs
@@ -35,15 +35,13 @@ public static class ClaimExtensions
     /// Gets the organisation of a user by deserializing the organisation claim.
     /// </summary>
     /// <returns>
-    /// The deserialized <see cref="Organisation"/>.
+    /// The deserialized <see cref="Organisation"/>, or a value of <c>null</c> if no
+    /// organisation has been provided for the user.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     /// If <paramref name="principal"/> is <c>null</c>
     /// </exception>
-    /// <exception cref="InvalidOperationException">
-    /// If <paramref name="principal"/> doesn't contain the organisation claim.
-    /// </exception>
-    public static Organisation GetOrganisation(this ClaimsPrincipal principal)
+    public static Organisation? GetOrganisation(this ClaimsPrincipal principal)
     {
         if (principal == null) {
             throw new ArgumentNullException(nameof(principal));
@@ -54,9 +52,15 @@ public static class ClaimExtensions
             .FirstOrDefault();
 
         if (organisationJson == null) {
-            throw new InvalidOperationException("Organisation was not set.");
+            return null;
         }
 
-        return JsonHelpers.Deserialize<Organisation>(organisationJson)!;
+        var organisation = JsonHelpers.Deserialize<Organisation>(organisationJson)!;
+
+        if (organisation.Id == Guid.Empty) {
+            return null;
+        }
+
+        return organisation;
     }
 }

--- a/Dfe.SchoolAccount.Web.Tests/Authorization/RestrictToSchoolUsersAuthorizationHandlerTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Authorization/RestrictToSchoolUsersAuthorizationHandlerTests.cs
@@ -1,0 +1,61 @@
+﻿namespace Dfe.SchoolAccount.Web.Tests.Services;
+
+using Dfe.SchoolAccount.Web.Authorization;
+using Dfe.SchoolAccount.Web.Services.Personas;
+using Dfe.SchoolAccount.Web.Tests.Fakes;
+using Microsoft.AspNetCore.Authorization;
+
+[TestClass]
+public sealed class RestrictToSchoolUsersAuthorizationHandlerTests
+{
+    #region Constructor
+
+    [TestMethod]
+    public void Constructor__ThrowsArgumentNullException__WhenPersonaResolverArgumentIsNull()
+    {
+        var act = () => {
+            _ = new RestrictToSchoolUsersAuthorizationHandler(null!);
+        };
+
+        Assert.ThrowsException<ArgumentNullException>(act);
+    }
+
+    #endregion
+
+    #region Task HandleAsync(AuthorizationHandlerContext)
+
+    [DataRow(PersonaName.AcademyTrustUser)]
+    [DataRow(PersonaName.AcademySchoolUser)]
+    [DataRow(PersonaName.LaMaintainedSchoolUser)]
+    [DataTestMethod]
+    public async Task HandleAsync__DoesNotBlockAccess__ForSchoolUser(PersonaName personaName)
+    {
+        var personaResolver = new FakePersonaResolver(personaName);
+        var restrictedAccessAuthorizationHandler = new RestrictToSchoolUsersAuthorizationHandler(personaResolver);
+
+        var user = UserFakesHelper.CreateFakeAuthenticatedUser();
+        var authorizationRequirements = Array.Empty<IAuthorizationRequirement>();
+        var authorizationHandlerContext = new AuthorizationHandlerContext(authorizationRequirements, user, null);
+
+        await restrictedAccessAuthorizationHandler.HandleAsync(authorizationHandlerContext);
+
+        Assert.IsFalse(authorizationHandlerContext.HasFailed);
+    }
+
+    [TestMethod]
+    public async Task HandleAsync__BlocksAccess__ForNonSchoolUser()
+    {
+        var personaResolver = new FakePersonaResolver(PersonaName.Unknown);
+        var restrictedAccessAuthorizationHandler = new RestrictToSchoolUsersAuthorizationHandler(personaResolver);
+
+        var user = UserFakesHelper.CreateFakeAuthenticatedUser();
+        var authorizationRequirements = Array.Empty<IAuthorizationRequirement>();
+        var authorizationHandlerContext = new AuthorizationHandlerContext(authorizationRequirements, user, null);
+
+        await restrictedAccessAuthorizationHandler.HandleAsync(authorizationHandlerContext);
+
+        Assert.IsTrue(authorizationHandlerContext.HasFailed);
+    }
+
+    #endregion
+}

--- a/Dfe.SchoolAccount.Web.Tests/Authorization/RestrictToSchoolUsersAuthorizationHandlerTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Authorization/RestrictToSchoolUsersAuthorizationHandlerTests.cs
@@ -33,7 +33,7 @@ public sealed class RestrictToSchoolUsersAuthorizationHandlerTests
         var personaResolver = new FakePersonaResolver(personaName);
         var restrictedAccessAuthorizationHandler = new RestrictToSchoolUsersAuthorizationHandler(personaResolver);
 
-        var user = UserFakesHelper.CreateFakeAuthenticatedUser();
+        var user = UserFakesHelper.CreateFakeAuthenticatedEstablishmentUser(1, "Test establishment name");
         var authorizationRequirements = Array.Empty<IAuthorizationRequirement>();
         var authorizationHandlerContext = new AuthorizationHandlerContext(authorizationRequirements, user, null);
 
@@ -48,7 +48,7 @@ public sealed class RestrictToSchoolUsersAuthorizationHandlerTests
         var personaResolver = new FakePersonaResolver(PersonaName.Unknown);
         var restrictedAccessAuthorizationHandler = new RestrictToSchoolUsersAuthorizationHandler(personaResolver);
 
-        var user = UserFakesHelper.CreateFakeAuthenticatedUser();
+        var user = UserFakesHelper.CreateFakeAuthenticatedOrganisationUser(123, "Test organisation name");
         var authorizationRequirements = Array.Empty<IAuthorizationRequirement>();
         var authorizationHandlerContext = new AuthorizationHandlerContext(authorizationRequirements, user, null);
 

--- a/Dfe.SchoolAccount.Web.Tests/Authorization/RestrictedAccessAuthorizationHandlerTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Authorization/RestrictedAccessAuthorizationHandlerTests.cs
@@ -1,7 +1,7 @@
 ﻿namespace Dfe.SchoolAccount.Web.Tests.Services;
 
 using Dfe.SchoolAccount.Web.Authorization;
-using Dfe.SchoolAccount.Web.Tests.Helpers;
+using Dfe.SchoolAccount.Web.Tests.Fakes;
 using Microsoft.AspNetCore.Authorization;
 
 [TestClass]

--- a/Dfe.SchoolAccount.Web.Tests/Authorization/RestrictedAccessAuthorizationHandlerTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Authorization/RestrictedAccessAuthorizationHandlerTests.cs
@@ -64,6 +64,22 @@ public sealed class RestrictedAccessAuthorizationHandlerTests
     }
 
     [TestMethod]
+    public async Task HandleAsync__BlocksAccess__WhenUserIsNotMemberOfAnyOrganisation()
+    {
+        var configuration = new RestrictedAccessConfiguration();
+        var restrictedAccessAuthorizationHandler = new RestrictedAccessAuthorizationHandler(configuration);
+
+        var user = UserFakesHelper.CreateFakeAuthenticatedUser();
+
+        var authorizationRequirements = Array.Empty<IAuthorizationRequirement>();
+        var authorizationHandlerContext = new AuthorizationHandlerContext(authorizationRequirements, user, null);
+
+        await restrictedAccessAuthorizationHandler.HandleAsync(authorizationHandlerContext);
+
+        Assert.IsTrue(authorizationHandlerContext.HasFailed);
+    }
+
+    [TestMethod]
     public async Task HandleAsync__BlocksAccess__WhenUserIsNotMemberOfPermittedOrganisation()
     {
         var configuration = new RestrictedAccessConfiguration {

--- a/Dfe.SchoolAccount.Web.Tests/Controllers/AccountControllerTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Controllers/AccountControllerTests.cs
@@ -1,6 +1,7 @@
 namespace Dfe.SchoolAccount.Web.Tests.Controllers;
 
 using Dfe.SchoolAccount.Web.Controllers;
+using Dfe.SchoolAccount.Web.Tests.Fakes;
 using Dfe.SchoolAccount.Web.Tests.Helpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/Dfe.SchoolAccount.Web.Tests/Controllers/HomeControllerTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Controllers/HomeControllerTests.cs
@@ -3,6 +3,7 @@ namespace Dfe.SchoolAccount.Web.Tests.Controllers;
 using Dfe.SchoolAccount.Web.Controllers;
 using Dfe.SchoolAccount.Web.Models;
 using Dfe.SchoolAccount.Web.Services.Personas;
+using Dfe.SchoolAccount.Web.Tests.Fakes;
 using Dfe.SchoolAccount.Web.Tests.Helpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/Dfe.SchoolAccount.Web.Tests/Fakes/FakePersonaResolver.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Fakes/FakePersonaResolver.cs
@@ -1,0 +1,19 @@
+﻿namespace Dfe.SchoolAccount.Web.Tests.Fakes;
+
+using System.Security.Claims;
+using Dfe.SchoolAccount.Web.Services.Personas;
+
+public sealed class FakePersonaResolver : IPersonaResolver
+{
+    private readonly PersonaName resolvedPersona;
+
+    public FakePersonaResolver(PersonaName resolvedPersona)
+    {
+        this.resolvedPersona = resolvedPersona;
+    }
+
+    public PersonaName ResolvePersona(ClaimsPrincipal principal)
+    {
+        return this.resolvedPersona;
+    }
+}

--- a/Dfe.SchoolAccount.Web.Tests/Fakes/UserFakesHelper.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Fakes/UserFakesHelper.cs
@@ -1,4 +1,4 @@
-﻿namespace Dfe.SchoolAccount.Web.Tests.Helpers;
+﻿namespace Dfe.SchoolAccount.Web.Tests.Fakes;
 
 using System.Security.Claims;
 using Dfe.SchoolAccount.SignIn.Constants;

--- a/Dfe.SchoolAccount.Web.Tests/Services/OrganisationPersonaResolverTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Services/OrganisationPersonaResolverTests.cs
@@ -3,7 +3,7 @@
 using System.Security.Claims;
 using Dfe.SchoolAccount.SignIn.Models;
 using Dfe.SchoolAccount.Web.Services.Personas;
-using Dfe.SchoolAccount.Web.Tests.Helpers;
+using Dfe.SchoolAccount.Web.Tests.Fakes;
 
 [TestClass]
 public sealed class OrganisationTypePersonaResolverTests

--- a/Dfe.SchoolAccount.Web/Authorization/RestrictToSchoolUsersAuthorizationHandler.cs
+++ b/Dfe.SchoolAccount.Web/Authorization/RestrictToSchoolUsersAuthorizationHandler.cs
@@ -1,0 +1,45 @@
+﻿namespace Dfe.SchoolAccount.Web.Authorization;
+
+using System.Threading.Tasks;
+using Dfe.SchoolAccount.Web.Services.Personas;
+using Microsoft.AspNetCore.Authorization;
+
+/// <summary>
+/// An authorization handler which only permits access for school users based on the
+/// resolved persona.
+/// </summary>
+/// <seealso cref="Dfe.SchoolAccount.Web.Services.Personas.IPersonaResolver"/>
+public sealed class RestrictToSchoolUsersAuthorizationHandler : IAuthorizationHandler
+{
+    private readonly IPersonaResolver personaResolver;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RestrictToSchoolUsersAuthorizationHandler"/> class.
+    /// </summary>
+    /// <param name="personaResolver">A service which resolves the persona of a user.</param>
+    /// <exception cref="ArgumentNullException">
+    /// If <paramref name="personaResolver"/> is <c>null</c>.
+    /// </exception>
+    public RestrictToSchoolUsersAuthorizationHandler(IPersonaResolver personaResolver)
+    {
+        if (personaResolver == null) {
+            throw new ArgumentNullException(nameof(personaResolver));
+        }
+
+        this.personaResolver = personaResolver;
+    }
+
+    /// <inheritdoc/>
+    public Task HandleAsync(AuthorizationHandlerContext context)
+    {
+        if (context.User != null) {
+            var resolvedPersona = this.personaResolver.ResolvePersona(context.User);
+            if (resolvedPersona == PersonaName.Unknown) {
+                string reason = "Not a school user.";
+                context.Fail(new AuthorizationFailureReason(this, reason));
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/Dfe.SchoolAccount.Web/Authorization/RestrictToSchoolUsersAuthorizationHandler.cs
+++ b/Dfe.SchoolAccount.Web/Authorization/RestrictToSchoolUsersAuthorizationHandler.cs
@@ -37,6 +37,7 @@ public sealed class RestrictToSchoolUsersAuthorizationHandler : IAuthorizationHa
             if (resolvedPersona == PersonaName.Unknown) {
                 string reason = "Not a school user.";
                 context.Fail(new AuthorizationFailureReason(this, reason));
+                return Task.CompletedTask;
             }
         }
 

--- a/Dfe.SchoolAccount.Web/Authorization/RestrictedAccessAuthorizationHandler.cs
+++ b/Dfe.SchoolAccount.Web/Authorization/RestrictedAccessAuthorizationHandler.cs
@@ -34,9 +34,16 @@ public sealed class RestrictedAccessAuthorizationHandler : IAuthorizationHandler
         if (context.User?.Identity?.IsAuthenticated == true) {
             var organisation = context.User.GetOrganisation();
 
+            if (organisation == null) {
+                string reason = "User does not have an organisation with their account.";
+                context.Fail(new AuthorizationFailureReason(this, reason));
+                return Task.CompletedTask;
+            }
+
             if (!this.configuration.PermittedOrganisationIds.Contains(organisation.Id)) {
                 string reason = "User organisation does not currently have access to the service.";
                 context.Fail(new AuthorizationFailureReason(this, reason));
+                return Task.CompletedTask;
             }
         }
 

--- a/Dfe.SchoolAccount.Web/Authorization/RestrictedAccessAuthorizationHandler.cs
+++ b/Dfe.SchoolAccount.Web/Authorization/RestrictedAccessAuthorizationHandler.cs
@@ -4,6 +4,10 @@ using System.Threading.Tasks;
 using Dfe.SchoolAccount.SignIn.Extensions;
 using Microsoft.AspNetCore.Authorization;
 
+/// <summary>
+/// An authorization handler which only permits access for users who are in permitted
+/// organisations.
+/// </summary>
 public sealed class RestrictedAccessAuthorizationHandler : IAuthorizationHandler
 {
     private readonly IRestrictedAccessConfiguration configuration;

--- a/Dfe.SchoolAccount.Web/Controllers/HomeController.cs
+++ b/Dfe.SchoolAccount.Web/Controllers/HomeController.cs
@@ -24,7 +24,7 @@ public sealed class HomeController : Controller
     [Route("/home")]
     public IActionResult Index()
     {
-        var organisation = this.User.GetOrganisation();
+        var organisation = this.User.GetOrganisation()!;
 
         var personaTypeName = this.personaResolver.ResolvePersona(this.User);
         Console.WriteLine("Persona type: " + personaTypeName);

--- a/Dfe.SchoolAccount.Web/Program.cs
+++ b/Dfe.SchoolAccount.Web/Program.cs
@@ -32,6 +32,8 @@ if (restrictedAccessSection.Exists()) {
     builder.Services.AddSingleton<IAuthorizationHandler, RestrictedAccessAuthorizationHandler>();
 }
 
+builder.Services.AddSingleton<IAuthorizationHandler, RestrictToSchoolUsersAuthorizationHandler>();
+
 //Sample to add authorisation to restrict user access to service based on a claim value
 //services.AddAuthorization(options =>
 //{

--- a/Dfe.SchoolAccount.Web/Services/Personas/IPersonaResolver.cs
+++ b/Dfe.SchoolAccount.Web/Services/Personas/IPersonaResolver.cs
@@ -14,5 +14,8 @@ public interface IPersonaResolver
     /// <returns>
     /// The resolved persona name; otherwise, a value of <see cref="PersonaName.Unknown"/>.
     /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// If <paramref name="principal"/> is <c>null</c>.
+    /// </exception>
     PersonaName ResolvePersona(ClaimsPrincipal principal);
 }

--- a/Dfe.SchoolAccount.Web/Services/Personas/OrganisationPersonaResolver.cs
+++ b/Dfe.SchoolAccount.Web/Services/Personas/OrganisationPersonaResolver.cs
@@ -40,11 +40,11 @@ public sealed class OrganisationTypePersonaResolver : IPersonaResolver
             throw new ArgumentNullException(nameof(principal));
         }
 
-        if (!principal.HasClaim(claim => claim.Type == ClaimConstants.Organisation)) {
+        var organisation = principal.GetOrganisation();
+
+        if (organisation == null) {
             return PersonaName.Unknown;
         }
-
-        var organisation = principal.GetOrganisation();
 
         if (organisation.Category.Id == OrganisationCategory.Establishment) {
             if (organisation.Type.Id == EstablishmentType.CommunitySchool) {


### PR DESCRIPTION
Restricts access to users for whom this service is targeted at.

## How to test
- Verify that school account users are able to access the service.
- Verify that a non-school account user is unable to access the service.