### PR TITLE
Use `AddAzureKeyVault` to access configuration from a configured Azure Key Vault

### DIFF
--- a/Dfe.SchoolAccount.Web/Dfe.SchoolAccount.Web.csproj
+++ b/Dfe.SchoolAccount.Web/Dfe.SchoolAccount.Web.csproj
@@ -20,4 +20,9 @@
     <InternalsVisibleTo Include="Dfe.SchoolAccount.Web.Tests" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
+    <PackageReference Include="Azure.Identity" Version="1.9.0" />
+  </ItemGroup>
+
 </Project>

--- a/Dfe.SchoolAccount.Web/Program.cs
+++ b/Dfe.SchoolAccount.Web/Program.cs
@@ -6,13 +6,13 @@ using Microsoft.AspNetCore.Authorization;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
-builder.Configuration.AddEnvironmentVariables("DFE_SA_");
+//builder.Configuration.AddEnvironmentVariables("DFE_SA_");
 
-if (builder.Environment.IsProduction()) {
-    builder.Configuration.AddAzureKeyVault(
-        new Uri($"https://{builder.Configuration["KeyVaultName"]}.vault.azure.net/"),
-        new DefaultAzureCredential());
-}
+//if (builder.Environment.IsProduction()) {
+//    builder.Configuration.AddAzureKeyVault(
+//        new Uri($"https://{builder.Configuration["KeyVaultName"]}.vault.azure.net/"),
+//        new DefaultAzureCredential());
+//}
 
 builder.Services.Configure<RequestLocalizationOptions>(options => {
     var supportedCultures = new[] { "en" /*, "cy"*/ };

--- a/Dfe.SchoolAccount.Web/Program.cs
+++ b/Dfe.SchoolAccount.Web/Program.cs
@@ -6,6 +6,8 @@ using Microsoft.AspNetCore.Authorization;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
+builder.Configuration.AddEnvironmentVariables("DFE_SA_");
+
 if (builder.Environment.IsProduction()) {
     builder.Configuration.AddAzureKeyVault(
         new Uri($"https://{builder.Configuration["KeyVaultName"]}.vault.azure.net/"),

--- a/Dfe.SchoolAccount.Web/Program.cs
+++ b/Dfe.SchoolAccount.Web/Program.cs
@@ -1,9 +1,16 @@
+using Azure.Identity;
 using Dfe.SchoolAccount.SignIn;
 using Dfe.SchoolAccount.Web.Authorization;
 using Dfe.SchoolAccount.Web.Services.Personas;
 using Microsoft.AspNetCore.Authorization;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+if (builder.Environment.IsProduction()) {
+    builder.Configuration.AddAzureKeyVault(
+        new Uri($"https://{builder.Configuration["KeyVaultName"]}.vault.azure.net/"),
+        new DefaultAzureCredential());
+}
 
 builder.Services.Configure<RequestLocalizationOptions>(options => {
     var supportedCultures = new[] { "en" /*, "cy"*/ };

--- a/Dfe.SchoolAccount.Web/Program.cs
+++ b/Dfe.SchoolAccount.Web/Program.cs
@@ -8,11 +8,12 @@ WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 builder.Configuration.AddEnvironmentVariables("DFE_SA_");
 
-//if (builder.Environment.IsProduction()) {
-//    builder.Configuration.AddAzureKeyVault(
-//        new Uri($"https://{builder.Configuration["KeyVaultName"]}.vault.azure.net/"),
-//        new DefaultAzureCredential());
-//}
+if (!string.IsNullOrEmpty(builder.Configuration["KeyVaultName"])) {
+    builder.Configuration.AddAzureKeyVault(
+        new Uri($"https://{builder.Configuration["KeyVaultName"]}.vault.azure.net/"),
+        new DefaultAzureCredential()
+    );
+}
 
 builder.Services.Configure<RequestLocalizationOptions>(options => {
     var supportedCultures = new[] { "en" /*, "cy"*/ };

--- a/Dfe.SchoolAccount.Web/Program.cs
+++ b/Dfe.SchoolAccount.Web/Program.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Authorization;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
-//builder.Configuration.AddEnvironmentVariables("DFE_SA_");
+builder.Configuration.AddEnvironmentVariables("DFE_SA_");
 
 //if (builder.Environment.IsProduction()) {
 //    builder.Configuration.AddAzureKeyVault(

--- a/Dfe.SchoolAccount.Web/appsettings.json
+++ b/Dfe.SchoolAccount.Web/appsettings.json
@@ -8,6 +8,8 @@
 
   "AllowedHosts": "*",
 
+  "KeyVaultName":  "<key_vault_name>",
+
   "DfePublicApi": {
     "BaseUrl": "<base_url>",
     "ServiceAudience": "signin.education.gov.uk",


### PR DESCRIPTION
The purpose of this is to allow the web application to read secrets from an Azure Key Vault when deployed.

## How to test
1. Set an environment variable with the name `DFE_SA_KeyStoreName` which identifies the Azure Key Vault.
2. Deploy this branch to an environment.
3. Verify that the application is able to read secrets from the Azure Key Vault.