### PR TITLE
Add section on configuring Contentful space secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ dotnet user-secrets set "DfeSignIn:ClientSecret" "<client_secret>"
 
 > **DO NOT** place secrets into any appsettings.json file inside the project since they may be inadvertently committed to the repository.
 
+
+## Configuring Contentful space secrets
+
+The application will need access to a Contentful space to be able to retrieve information to display to the user. You may error out once you log in through DfE Sign-in without these secrets set.
+
+Once you have a Space ID, a Delivery API key and a Preview API key, you can set them as follows:
+
+```bash
+dotnet user-secrets set "ContentfulOptions:SpaceId" "<space_id>"
+dotnet user-secrets set "ContentfulOptions:DeliveryApiKey" "<delivery_api_key>"
+dotnet user-secrets set "ContentfulOptions:PreviewApiKey" "<preview_api_key>"
+```
+
 ## Restricting access to users of permitted organisations
 
 Service access can be restricted to users of permitted organisations by providing a list of organisation GUID's. Access is not restricted when this configuration is not provided.


### PR DESCRIPTION
If you sign in successfully through DSI on the application without Contentful secrets set, you will receive the following error in the browser:

![firefox_9aYommzrwc](https://github.com/DFE-Digital/school-account/assets/9040571/b447ddd3-83e8-4912-a01e-3158f984dcb6)

I have only tested this without `SpaceId` set but I would assume based on the stack trace and where this call to Contentful occurs in code that you will receive a similar error if you've missed any of the required secrets.

@kruncher, I've noticed on the Contenful docs and in the `appsettings.json` that there's also a `ManagementApiKey` that you are able to set - is this (or will it be) required?

## How to test
Review the amended documentation text.