### PR TITLE
Add general error page content with a special case for "Your institution is not yet eligible for this service"

### DIFF
--- a/Dfe.SchoolAccount.Web.Tests/Authorization/FailedAuthorizationMiddlewareResultHandlerTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Authorization/FailedAuthorizationMiddlewareResultHandlerTests.cs
@@ -1,0 +1,93 @@
+﻿namespace Dfe.SchoolAccount.Web.Tests.Authorization;
+
+using Dfe.SchoolAccount.Web.Authorization;
+using Dfe.SchoolAccount.Web.Constants;
+using Dfe.SchoolAccount.Web.Tests.Helpers;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Policy;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+[TestClass]
+public sealed class FailedAuthorizationMiddlewareResultHandlerTests
+{
+    #region Task HandleAsync(RequestDelegate, HttpContext, AuthorizationPolicy, PolicyAuthorizationResult)
+
+    [TestMethod]
+    public async Task HandleAsync__RedirectsToYourInstitutionIsNotYetEligibleForThisServicePage__WhenFailureOccurs()
+    {
+        var logger = new NullLogger<FailedAuthorizationMiddlewareResultHandler>();
+        var defaultHandlerMock = new Mock<IAuthorizationMiddlewareResultHandler>();
+        var failedAuthorizationMiddlewareResultHandler = new FailedAuthorizationMiddlewareResultHandler(logger, defaultHandlerMock.Object);
+
+        var next = (RequestDelegate)(context => Task.CompletedTask);
+
+        var responseMock = new Mock<HttpResponse>();
+        var contextMock = new Mock<HttpContext>();
+        contextMock.SetupGet(mock => mock.Response)
+            .Returns(responseMock.Object);
+
+        var policy = (AuthorizationPolicy)null!;
+        var authorizeResult = PolicyAuthorizationResult.Forbid(
+            AuthorizationFailure.Failed(new AuthorizationFailureReason[] {
+                new AuthorizationFailureReason(null!, AuthorizationFailureConstants.YourInstitutionIsNotYetEligibleForThisService),
+            })
+        );
+
+        await failedAuthorizationMiddlewareResultHandler.HandleAsync(next, contextMock.Object, policy, authorizeResult);
+
+        responseMock.Verify(mock => mock.Redirect(It.Is<string>(param => "/your-institution-is-not-yet-eligible-for-this-service" == param)));
+    }
+
+    [TestMethod]
+    public async Task HandleAsync__RevertsToDefaultHandler__WhenDifferentAuthorizationFailuresHaveOccurred()
+    {
+        var logger = new NullLogger<FailedAuthorizationMiddlewareResultHandler>();
+        var defaultHandlerMock = new Mock<IAuthorizationMiddlewareResultHandler>();
+        var failedAuthorizationMiddlewareResultHandler = new FailedAuthorizationMiddlewareResultHandler(logger, defaultHandlerMock.Object);
+
+        var next = (RequestDelegate)(context => Task.CompletedTask);
+        var contextMock = new Mock<HttpContext>();
+        var policy = (AuthorizationPolicy)null!;
+        var authorizeResult = PolicyAuthorizationResult.Forbid(
+            AuthorizationFailure.Failed(new AuthorizationFailureReason[] {
+                new AuthorizationFailureReason(null!, "Some other reason."),
+            })
+        );
+
+        await failedAuthorizationMiddlewareResultHandler.HandleAsync(next, contextMock.Object, policy, authorizeResult);
+
+        defaultHandlerMock.Verify(mock => mock.HandleAsync(
+            It.Is<RequestDelegate>(param => next == param),
+            It.Is<HttpContext>(param => contextMock.Object == param),
+            It.Is<AuthorizationPolicy>(param => policy == param),
+            It.Is<PolicyAuthorizationResult>(param => authorizeResult == param)
+        ));
+    }
+
+    [TestMethod]
+    public async Task HandleAsync__RevertsToDefaultHandler__WhenNoAuthorizationFailuresHaveOccurred()
+    {
+        var logger = new NullLogger<FailedAuthorizationMiddlewareResultHandler>();
+        var defaultHandlerMock = new Mock<IAuthorizationMiddlewareResultHandler>();
+        var failedAuthorizationMiddlewareResultHandler = new FailedAuthorizationMiddlewareResultHandler(logger, defaultHandlerMock.Object);
+
+        var next = (RequestDelegate)(context => Task.CompletedTask);
+        var contextMock = new Mock<HttpContext>();
+        var policy = (AuthorizationPolicy)null!;
+        var authorizeResult = PolicyAuthorizationResult.Success();
+
+        await failedAuthorizationMiddlewareResultHandler.HandleAsync(next, contextMock.Object, policy, authorizeResult);
+
+        defaultHandlerMock.Verify(mock => mock.HandleAsync(
+            It.Is<RequestDelegate>(param => next == param),
+            It.Is<HttpContext>(param => contextMock.Object == param),
+            It.Is<AuthorizationPolicy>(param => policy == param),
+            It.Is<PolicyAuthorizationResult>(param => authorizeResult == param)
+        ));
+    }
+
+    #endregion
+}

--- a/Dfe.SchoolAccount.Web.Tests/Controllers/ErrorPageControllerTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Controllers/ErrorPageControllerTests.cs
@@ -1,0 +1,63 @@
+namespace Dfe.SchoolAccount.Web.Tests.Controllers;
+
+using Dfe.SchoolAccount.Web.Controllers;
+using Dfe.SchoolAccount.Web.Models.Content;
+using Dfe.SchoolAccount.Web.Services.Content;
+using Dfe.SchoolAccount.Web.Tests.Helpers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+[TestClass]
+public sealed class ErrorPageControllerTests
+{
+    private static ErrorPageController CreateErrorPageControllerWithFakeContent(ErrorPageContent fakeErrorPage)
+    {
+        var logger = new NullLogger<ErrorPageController>();
+
+        var errorPageContentFetcherMock = new Mock<IErrorPageContentFetcher>();
+        errorPageContentFetcherMock.Setup(mock => mock.FetchErrorPageContentAsync(It.Is<string>(slug => slug == "an-example-error-handle")))
+            .ReturnsAsync(fakeErrorPage);
+
+        return new ErrorPageController(logger, errorPageContentFetcherMock.Object);
+    }
+
+    #region Task<IActionResult> Index(string)
+
+    [TestMethod]
+    public async Task Index__ReturnsNotFound__WhenContentForHandleWasNotFound()
+    {
+        var fakeErrorPage = new ErrorPageContent();
+        var errorPageController = CreateErrorPageControllerWithFakeContent(fakeErrorPage);
+
+        var result = await errorPageController.Index("a-slug-that-does-not-exist", 403);
+
+        TypeAssert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [TestMethod]
+    public async Task Index__ReturnsExpectedView()
+    {
+        var fakeErrorPage = new ErrorPageContent();
+        var errorPageController = CreateErrorPageControllerWithFakeContent(fakeErrorPage);
+
+        var result = await errorPageController.Index("an-example-error-handle", 403);
+
+        var viewResult = TypeAssert.IsType<ViewResult>(result);
+        Assert.AreEqual(403, viewResult.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task Index__ProvidesErrorPageContentAsViewModel()
+    {
+        var fakeErrorPage = new ErrorPageContent();
+        var errorPageController = CreateErrorPageControllerWithFakeContent(fakeErrorPage);
+
+        var result = await errorPageController.Index("an-example-error-handle", 403);
+
+        var viewResult = TypeAssert.IsType<ViewResult>(result);
+        Assert.AreSame(fakeErrorPage, viewResult.Model);
+    }
+
+    #endregion
+}

--- a/Dfe.SchoolAccount.Web.Tests/Services/Content/ContentfulErrorPageContentFetcherTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Services/Content/ContentfulErrorPageContentFetcherTests.cs
@@ -1,0 +1,93 @@
+﻿namespace Dfe.SchoolAccount.Web.Tests.Services.Content;
+
+using Contentful.Core;
+using Contentful.Core.Models;
+using Contentful.Core.Search;
+using Dfe.SchoolAccount.Web.Models.Content;
+using Dfe.SchoolAccount.Web.Services.Content;
+using Dfe.SchoolAccount.Web.Services.ContentTransformers;
+using Moq;
+
+[TestClass]
+public sealed class ContentfulErrorPageContentFetcherTests
+{
+    #region Constructor
+
+    [TestMethod]
+    public void Constructor__ThrowsArgumentNullException__WhenContentfulClientArgumentIsNull()
+    {
+        var act = () => {
+            _ = new ContentfulErrorPageContentFetcher(null!);
+        };
+
+        Assert.ThrowsException<ArgumentNullException>(() => act());
+    }
+
+    #endregion
+
+    #region Task<ErrorPageContent> FetchErrorPageContentAsync(string)
+
+    [TestMethod]
+    public async Task FetchErrorPageContentAsync__ThrowsArgumentNullException__WhenHandleArgumentIsNull()
+    {
+        var contentfulClientMock = new Mock<IContentfulClient>();
+        var contentModelTransformerMock = new Mock<IContentModelTransformer>();
+        var contentfulErrorPageContentFetcher = new ContentfulErrorPageContentFetcher(contentfulClientMock.Object);
+
+        var act = async () => {
+            _ = await contentfulErrorPageContentFetcher.FetchErrorPageContentAsync(null!);
+        };
+
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(act);
+    }
+
+    [TestMethod]
+    public async Task FetchErrorPageContentAsync__ThrowsArgumentException__WhenHandleArgumentIsAnEmptyString()
+    {
+        var contentfulClientMock = new Mock<IContentfulClient>();
+        var contentfulErrorPageContentFetcher = new ContentfulErrorPageContentFetcher(contentfulClientMock.Object);
+
+        var act = async () => {
+            _ = await contentfulErrorPageContentFetcher.FetchErrorPageContentAsync("");
+        };
+
+        var exception = await Assert.ThrowsExceptionAsync<ArgumentException>(act);
+        Assert.AreEqual("Cannot be an empty string. (Parameter 'handle')", exception.Message);
+    }
+
+    [TestMethod]
+    public async Task FetchErrorPageContentAsync__ReturnsNull__WhenContentfulClientReturnsNoEntries()
+    {
+        var contentfulClientMock = new Mock<IContentfulClient>();
+        contentfulClientMock.Setup(mock => mock.GetEntries(It.IsAny<QueryBuilder<ErrorPageContent>>(), default))
+            .ReturnsAsync(new ContentfulCollection<ErrorPageContent> {
+                Items = Array.Empty<ErrorPageContent>(),
+            });
+
+        var contentfulErrorPageContentFetcher = new ContentfulErrorPageContentFetcher(contentfulClientMock.Object);
+
+        var entry = await contentfulErrorPageContentFetcher.FetchErrorPageContentAsync("a-handle-with-does-not-exist");
+
+        Assert.IsNull(entry);
+    }
+
+    [TestMethod]
+    public async Task FetchErrorPageContentAsync__ReturnsResultFromContentfulClient()
+    {
+        var fakeErrorPageContent = new ErrorPageContent();
+
+        var contentfulClientMock = new Mock<IContentfulClient>();
+        contentfulClientMock.Setup(mock => mock.GetEntries(It.IsAny<QueryBuilder<ErrorPageContent>>(), default))
+            .ReturnsAsync(new ContentfulCollection<ErrorPageContent> {
+                Items = new ErrorPageContent[] { fakeErrorPageContent },
+            });
+
+        var contentfulErrorPageContentFetcher = new ContentfulErrorPageContentFetcher(contentfulClientMock.Object);
+
+        var entry = await contentfulErrorPageContentFetcher.FetchErrorPageContentAsync("an-example-handle");
+
+        Assert.AreSame(fakeErrorPageContent, entry);
+    }
+
+    #endregion
+}

--- a/Dfe.SchoolAccount.Web.Tests/Services/Content/ContentfulHubContentFetcherTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Services/Content/ContentfulHubContentFetcherTests.cs
@@ -6,7 +6,6 @@ using Contentful.Core.Search;
 using Dfe.SchoolAccount.Web.Constants;
 using Dfe.SchoolAccount.Web.Models.Content;
 using Dfe.SchoolAccount.Web.Services.Content;
-using Dfe.SchoolAccount.Web.Services.ContentTransformers;
 using Dfe.SchoolAccount.Web.Services.Personas;
 using Moq;
 

--- a/Dfe.SchoolAccount.Web.Tests/Services/Content/ContentfulSignpostingPageContentFetcherTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Services/Content/ContentfulSignpostingPageContentFetcherTests.cs
@@ -3,11 +3,9 @@
 using Contentful.Core;
 using Contentful.Core.Models;
 using Contentful.Core.Search;
-using Dfe.SchoolAccount.Web.Constants;
 using Dfe.SchoolAccount.Web.Models.Content;
 using Dfe.SchoolAccount.Web.Services.Content;
 using Dfe.SchoolAccount.Web.Services.ContentTransformers;
-using Dfe.SchoolAccount.Web.Services.Personas;
 using Dfe.SchoolAccount.Web.Tests.Helpers;
 using Moq;
 
@@ -27,6 +25,7 @@ public sealed class ContentfulSignpostingPageContentFetcherTests
 
         Assert.ThrowsException<ArgumentNullException>(() => act());
     }
+
     [TestMethod]
     public void Constructor__ThrowsArgumentNullException__WhenContentModelTransformerArgumentIsNull()
     {

--- a/Dfe.SchoolAccount.Web/Authorization/FailedAuthorizationMiddlewareResultHandler.cs
+++ b/Dfe.SchoolAccount.Web/Authorization/FailedAuthorizationMiddlewareResultHandler.cs
@@ -1,0 +1,33 @@
+﻿namespace Dfe.SchoolAccount.Web.Authorization;
+
+using System.Threading.Tasks;
+using Dfe.SchoolAccount.Web.Constants;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Policy;
+using Microsoft.AspNetCore.Http;
+
+public sealed class FailedAuthorizationMiddlewareResultHandler : IAuthorizationMiddlewareResultHandler
+{
+    private readonly ILogger<AuthorizationMiddlewareResultHandler> logger;
+    private readonly AuthorizationMiddlewareResultHandler defaultHandler = new();
+
+    public FailedAuthorizationMiddlewareResultHandler(ILogger<AuthorizationMiddlewareResultHandler> logger)
+    {
+        this.logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task HandleAsync(RequestDelegate next, HttpContext context, AuthorizationPolicy policy, PolicyAuthorizationResult authorizeResult)
+    {
+        if (authorizeResult.AuthorizationFailure != null) {
+            this.logger.LogInformation($"Authorization failed with the reason '{authorizeResult.AuthorizationFailure.FailureReasons.FirstOrDefault()?.Message}'");
+
+            if (authorizeResult.AuthorizationFailure.FailureReasons.Any(reason => reason.Message == AuthorizationFailureConstants.YourInstitutionIsNotYetEligibleForThisService)) {
+                context.Response.Redirect($"/{ErrorPageConstants.YourInstitutionIsNotYetEligibleForThisServiceHandle}");
+                return;
+            }
+        }
+
+        await this.defaultHandler.HandleAsync(next, context, policy, authorizeResult);
+    }
+}

--- a/Dfe.SchoolAccount.Web/Authorization/FailedAuthorizationMiddlewareResultHandler.cs
+++ b/Dfe.SchoolAccount.Web/Authorization/FailedAuthorizationMiddlewareResultHandler.cs
@@ -8,12 +8,13 @@ using Microsoft.AspNetCore.Http;
 
 public sealed class FailedAuthorizationMiddlewareResultHandler : IAuthorizationMiddlewareResultHandler
 {
-    private readonly ILogger<AuthorizationMiddlewareResultHandler> logger;
-    private readonly AuthorizationMiddlewareResultHandler defaultHandler = new();
+    private readonly ILogger<FailedAuthorizationMiddlewareResultHandler> logger;
+    private readonly IAuthorizationMiddlewareResultHandler defaultHandler;
 
-    public FailedAuthorizationMiddlewareResultHandler(ILogger<AuthorizationMiddlewareResultHandler> logger)
+    public FailedAuthorizationMiddlewareResultHandler(ILogger<FailedAuthorizationMiddlewareResultHandler> logger, IAuthorizationMiddlewareResultHandler defaultHandler)
     {
         this.logger = logger;
+        this.defaultHandler = defaultHandler;
     }
 
     /// <inheritdoc/>

--- a/Dfe.SchoolAccount.Web/Authorization/RestrictToSchoolUsersAuthorizationHandler.cs
+++ b/Dfe.SchoolAccount.Web/Authorization/RestrictToSchoolUsersAuthorizationHandler.cs
@@ -1,6 +1,7 @@
 ﻿namespace Dfe.SchoolAccount.Web.Authorization;
 
 using System.Threading.Tasks;
+using Dfe.SchoolAccount.Web.Constants;
 using Dfe.SchoolAccount.Web.Services.Personas;
 using Microsoft.AspNetCore.Authorization;
 
@@ -35,8 +36,7 @@ public sealed class RestrictToSchoolUsersAuthorizationHandler : IAuthorizationHa
         if (context.User != null) {
             var resolvedPersona = this.personaResolver.ResolvePersona(context.User);
             if (resolvedPersona == PersonaName.Unknown) {
-                string reason = "Not a school user.";
-                context.Fail(new AuthorizationFailureReason(this, reason));
+                context.Fail(new AuthorizationFailureReason(this, AuthorizationFailureConstants.YourInstitutionIsNotYetEligibleForThisService));
                 return Task.CompletedTask;
             }
         }

--- a/Dfe.SchoolAccount.Web/Authorization/RestrictedAccessAuthorizationHandler.cs
+++ b/Dfe.SchoolAccount.Web/Authorization/RestrictedAccessAuthorizationHandler.cs
@@ -2,6 +2,7 @@
 
 using System.Threading.Tasks;
 using Dfe.SchoolAccount.SignIn.Extensions;
+using Dfe.SchoolAccount.Web.Constants;
 using Microsoft.AspNetCore.Authorization;
 
 /// <summary>
@@ -35,14 +36,12 @@ public sealed class RestrictedAccessAuthorizationHandler : IAuthorizationHandler
             var organisation = context.User.GetOrganisation();
 
             if (organisation == null) {
-                string reason = "User does not have an organisation with their account.";
-                context.Fail(new AuthorizationFailureReason(this, reason));
+                context.Fail(new AuthorizationFailureReason(this, AuthorizationFailureConstants.UserHasNoNoOrganisation));
                 return Task.CompletedTask;
             }
 
             if (!this.configuration.PermittedOrganisationIds.Contains(organisation.Id)) {
-                string reason = "User organisation does not currently have access to the service.";
-                context.Fail(new AuthorizationFailureReason(this, reason));
+                context.Fail(new AuthorizationFailureReason(this, AuthorizationFailureConstants.UserCannotAccessService));
                 return Task.CompletedTask;
             }
         }

--- a/Dfe.SchoolAccount.Web/Constants/AuthorizationFailureConstants.cs
+++ b/Dfe.SchoolAccount.Web/Constants/AuthorizationFailureConstants.cs
@@ -1,0 +1,8 @@
+﻿namespace Dfe.SchoolAccount.Web.Constants;
+
+public static class AuthorizationFailureConstants
+{
+    public const string UserHasNoNoOrganisation = "User does not have an organisation with their account";
+    public const string UserCannotAccessService = "User organisation does not currently have access to the service";
+    public const string YourInstitutionIsNotYetEligibleForThisService = "Your institution is not yet eligible for this service";
+}

--- a/Dfe.SchoolAccount.Web/Constants/ContentTypeConstants.cs
+++ b/Dfe.SchoolAccount.Web/Constants/ContentTypeConstants.cs
@@ -2,6 +2,7 @@
 
 public static class ContentTypeConstants
 {
+    public const string ErrorPage = "errorPage";
     public const string ExternalResource = "externalResource";
     public const string Hub = "hub";
     public const string SignpostingPage = "signpostingPage";

--- a/Dfe.SchoolAccount.Web/Constants/ErrorPageConstants.cs
+++ b/Dfe.SchoolAccount.Web/Constants/ErrorPageConstants.cs
@@ -1,0 +1,6 @@
+﻿namespace Dfe.SchoolAccount.Web.Constants;
+
+public static class ErrorPageConstants
+{
+    public const string YourInstitutionIsNotYetEligibleForThisServiceHandle = "your-institution-is-not-yet-eligible-for-this-service";
+}

--- a/Dfe.SchoolAccount.Web/Controllers/ErrorPageController.cs
+++ b/Dfe.SchoolAccount.Web/Controllers/ErrorPageController.cs
@@ -1,0 +1,36 @@
+﻿namespace Dfe.SchoolAccount.Web.Controllers;
+
+using Dfe.SchoolAccount.Web.Services.Content;
+using Microsoft.AspNetCore.Mvc;
+
+public sealed class ErrorPageController : Controller
+{
+    private readonly ILogger<ErrorPageController> logger;
+    private readonly IErrorPageContentFetcher errorPageContentFetcher;
+
+    public ErrorPageController(
+        ILogger<ErrorPageController> logger,
+        IErrorPageContentFetcher errorPageContentFetcher)
+    {
+        this.logger = logger;
+        this.errorPageContentFetcher = errorPageContentFetcher;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Index(string handle, int statusCode)
+    {
+        this.logger.LogInformation($"Error page '{handle}' was presented.");
+
+        var model = await this.errorPageContentFetcher.FetchErrorPageContentAsync(handle);
+
+        if (model == null) {
+            this.logger.LogError($"Could not find error page with the handle '{handle}'.");
+            return this.NotFound(handle);
+        }
+
+        var view = this.View("Index", model);
+        view.StatusCode = statusCode;
+
+        return view;
+    }
+}

--- a/Dfe.SchoolAccount.Web/Models/Content/ErrorPageContent.cs
+++ b/Dfe.SchoolAccount.Web/Models/Content/ErrorPageContent.cs
@@ -1,0 +1,14 @@
+﻿namespace Dfe.SchoolAccount.Web.Models.Content;
+
+using Contentful.Core.Models;
+
+public sealed class ErrorPageContent : IContent
+{
+    public string Handle { get; set; } = null!;
+
+    public string Title { get; set; } = null!;
+
+    public string Summary { get; set; } = null!;
+
+    public Document? Body { get; set; }
+}

--- a/Dfe.SchoolAccount.Web/Program.cs
+++ b/Dfe.SchoolAccount.Web/Program.cs
@@ -87,6 +87,7 @@ builder.Services.AddTransient((IServiceProvider sp) => {
 builder.Services.AddSingleton<IPersonaResolver, OrganisationTypePersonaResolver>();
 builder.Services.AddSingleton<IHubContentFetcher, ContentfulHubContentFetcher>();
 builder.Services.AddSingleton<ISignpostingPageContentFetcher, ContentfulSignpostingPageContentFetcher>();
+builder.Services.AddSingleton<IErrorPageContentFetcher, ContentfulErrorPageContentFetcher>();
 
 builder.Services.AddSingleton<IContentModelTransformHandler<ExternalResourceContent, CardModel>, ExternalResourceContentToCardTransformHandler>();
 builder.Services.AddSingleton<IContentModelTransformHandler<SignpostingPageContent, CardModel>, SignpostingPageContentToCardTransformHandler>();

--- a/Dfe.SchoolAccount.Web/Program.cs
+++ b/Dfe.SchoolAccount.Web/Program.cs
@@ -13,6 +13,7 @@ using Dfe.SchoolAccount.Web.Services.ContentTransformers.Cards;
 using Dfe.SchoolAccount.Web.Services.Personas;
 using Dfe.SchoolAccount.Web.Services.Rendering;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Policy;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Options;
@@ -60,7 +61,11 @@ if (restrictedAccessSection.Exists()) {
 }
 
 builder.Services.AddSingleton<IAuthorizationHandler, RestrictToSchoolUsersAuthorizationHandler>();
-builder.Services.AddSingleton<IAuthorizationMiddlewareResultHandler, FailedAuthorizationMiddlewareResultHandler>();
+builder.Services.AddSingleton<IAuthorizationMiddlewareResultHandler>((IServiceProvider sp) => {
+    var logger = sp.GetRequiredService<ILogger<FailedAuthorizationMiddlewareResultHandler>>();
+    var defaultHandler = new AuthorizationMiddlewareResultHandler();
+    return new FailedAuthorizationMiddlewareResultHandler(logger, defaultHandler);
+});
 
 //Sample to add authorisation to restrict user access to service based on a claim value
 //services.AddAuthorization(options =>

--- a/Dfe.SchoolAccount.Web/Program.cs
+++ b/Dfe.SchoolAccount.Web/Program.cs
@@ -5,6 +5,7 @@ using Contentful.Core.Configuration;
 using Contentful.Core.Models;
 using Dfe.SchoolAccount.SignIn;
 using Dfe.SchoolAccount.Web.Authorization;
+using Dfe.SchoolAccount.Web.Constants;
 using Dfe.SchoolAccount.Web.Models.Content;
 using Dfe.SchoolAccount.Web.Services.Content;
 using Dfe.SchoolAccount.Web.Services.ContentTransformers;
@@ -59,6 +60,7 @@ if (restrictedAccessSection.Exists()) {
 }
 
 builder.Services.AddSingleton<IAuthorizationHandler, RestrictToSchoolUsersAuthorizationHandler>();
+builder.Services.AddSingleton<IAuthorizationMiddlewareResultHandler, FailedAuthorizationMiddlewareResultHandler>();
 
 //Sample to add authorisation to restrict user access to service based on a claim value
 //services.AddAuthorization(options =>
@@ -127,6 +129,12 @@ app.MapControllerRoute(
     name: "restricted",
     pattern: "restricted",
     defaults: new { controller = "Error", action = "Index", statusCode = 403 }
+);
+
+app.MapControllerRoute(
+    name: ErrorPageConstants.YourInstitutionIsNotYetEligibleForThisServiceHandle,
+    pattern: ErrorPageConstants.YourInstitutionIsNotYetEligibleForThisServiceHandle,
+    defaults: new { controller = "ErrorPage", action = "Index", handle = ErrorPageConstants.YourInstitutionIsNotYetEligibleForThisServiceHandle, statusCode = 403 }
 );
 
 app.MapControllerRoute(

--- a/Dfe.SchoolAccount.Web/Services/Content/ContentfulErrorPageContentFetcher.cs
+++ b/Dfe.SchoolAccount.Web/Services/Content/ContentfulErrorPageContentFetcher.cs
@@ -1,0 +1,50 @@
+﻿namespace Dfe.SchoolAccount.Web.Services.Content;
+
+using System.Threading.Tasks;
+using Contentful.Core;
+using Contentful.Core.Search;
+using Dfe.SchoolAccount.Web.Constants;
+using Dfe.SchoolAccount.Web.Models.Content;
+
+/// <summary>
+/// A service which fetches signposting page content from a Contentful CDA.
+/// </summary>
+public sealed class ContentfulErrorPageContentFetcher : IErrorPageContentFetcher
+{
+    private readonly IContentfulClient contentfulClient;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ContentfulErrorPageContentFetcher"/> class.
+    /// </summary>
+    /// <param name="contentfulClient">The contentful client.</param>
+    /// <exception cref="ArgumentNullException">
+    /// If <paramref name="contentfulClient"/> is <c>null</c>.
+    /// </exception>
+    public ContentfulErrorPageContentFetcher(IContentfulClient contentfulClient)
+    {
+        if (contentfulClient == null) {
+            throw new ArgumentNullException(nameof(contentfulClient));
+        }
+
+        this.contentfulClient = contentfulClient;
+    }
+
+    /// <inheritdoc/>
+    public async Task<ErrorPageContent?> FetchErrorPageContentAsync(string handle)
+    {
+        if (handle == null) {
+            throw new ArgumentNullException(nameof(handle));
+        }
+        if (handle == "") {
+            throw new ArgumentException("Cannot be an empty string.", nameof(handle));
+        }
+
+        var errorPageEntries = await this.contentfulClient.GetEntries(
+            QueryBuilder<ErrorPageContent>.New
+                .ContentTypeIs(ContentTypeConstants.ErrorPage)
+                .FieldEquals("fields.handle", handle)
+        );
+
+        return errorPageEntries.SingleOrDefault();
+    }
+}

--- a/Dfe.SchoolAccount.Web/Services/Content/ContentfulErrorPageContentFetcher.cs
+++ b/Dfe.SchoolAccount.Web/Services/Content/ContentfulErrorPageContentFetcher.cs
@@ -7,7 +7,7 @@ using Dfe.SchoolAccount.Web.Constants;
 using Dfe.SchoolAccount.Web.Models.Content;
 
 /// <summary>
-/// A service which fetches signposting page content from a Contentful CDA.
+/// A service which fetches error page content from a Contentful CDA.
 /// </summary>
 public sealed class ContentfulErrorPageContentFetcher : IErrorPageContentFetcher
 {

--- a/Dfe.SchoolAccount.Web/Services/Content/IErrorPageContentFetcher.cs
+++ b/Dfe.SchoolAccount.Web/Services/Content/IErrorPageContentFetcher.cs
@@ -1,0 +1,25 @@
+﻿namespace Dfe.SchoolAccount.Web.Services.Content;
+
+using Dfe.SchoolAccount.Web.Models.Content;
+
+/// <summary>
+/// A service which fetches error page content.
+/// </summary>
+public interface IErrorPageContentFetcher
+{
+    /// <summary>
+    /// Fetches error page content with the given handle.
+    /// </summary>
+    /// <param name="handle">Unique handle of the error page.</param>
+    /// <returns>
+    /// An object with the error page content when found; otherwise, a value of
+    /// <c>null</c>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// If <paramref name="handle"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// If <paramref name="handle"/> is an empty string.
+    /// </exception>
+    Task<ErrorPageContent?> FetchErrorPageContentAsync(string handle);
+}

--- a/Dfe.SchoolAccount.Web/Services/Content/ISignpostingPageContentFetcher.cs
+++ b/Dfe.SchoolAccount.Web/Services/Content/ISignpostingPageContentFetcher.cs
@@ -8,7 +8,7 @@ using Dfe.SchoolAccount.Web.Models.Content;
 public interface ISignpostingPageContentFetcher
 {
     /// <summary>
-    /// Fetches hub content for a given persona.
+    /// Fetches the requested signposting page content.
     /// </summary>
     /// <param name="slug">Slug of the signposting page.</param>
     /// <returns>

--- a/Dfe.SchoolAccount.Web/Views/ErrorPage/Index.cshtml
+++ b/Dfe.SchoolAccount.Web/Views/ErrorPage/Index.cshtml
@@ -1,0 +1,15 @@
+﻿@using Dfe.SchoolAccount.Web.Models.Content;
+
+@model ErrorPageContent
+
+@inject IViewLocalizer ViewLocalizer
+
+@{
+    ViewData["Title"] = Model.Title;
+}
+
+<h1 class="govuk-heading-xl">
+    @ViewData["Title"]
+</h1>
+
+<contentful-rich-text document="@Model.Body"></contentful-rich-text>


### PR DESCRIPTION
## How to test
1. Sign into the service using an establishment type that does not resolve to a known persona. This can be faked by removing lines 50-53 from 'OrganisationPersonaResolver.cs'.
2. Verify that the "Your institution is not yet eligible for this service" error page is shown.