### PR TITLE
Add support for general content pages

### DIFF
--- a/Dfe.SchoolAccount.Web.Tests/Controllers/ErrorPageControllerTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Controllers/ErrorPageControllerTests.cs
@@ -32,7 +32,7 @@ public sealed class ErrorPageControllerTests
 
         var result = await errorPageController.Index("a-slug-that-does-not-exist", 403);
 
-        TypeAssert.IsType<NotFoundObjectResult>(result);
+        TypeAssert.IsType<NotFoundResult>(result);
     }
 
     [TestMethod]

--- a/Dfe.SchoolAccount.Web.Tests/Controllers/PageControllerTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Controllers/PageControllerTests.cs
@@ -1,0 +1,62 @@
+namespace Dfe.SchoolAccount.Web.Tests.Controllers;
+
+using Dfe.SchoolAccount.Web.Controllers;
+using Dfe.SchoolAccount.Web.Models.Content;
+using Dfe.SchoolAccount.Web.Services.Content;
+using Dfe.SchoolAccount.Web.Tests.Helpers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+[TestClass]
+public sealed class PageControllerTests
+{
+    private static PageController CreatePageControllerWithFakeContent(PageContent fakePage)
+    {
+        var logger = new NullLogger<PageController>();
+
+        var pageContentFetcherMock = new Mock<IPageContentFetcher>();
+        pageContentFetcherMock.Setup(mock => mock.FetchPageContentAsync(It.Is<string>(slug => slug == "an-example-page-handle")))
+            .ReturnsAsync(fakePage);
+
+        return new PageController(logger, pageContentFetcherMock.Object);
+    }
+
+    #region Task<IActionResult> Index(string)
+
+    [TestMethod]
+    public async Task Index__ReturnsNotFound__WhenContentForHandleWasNotFound()
+    {
+        var fakePage = new PageContent();
+        var pageController = CreatePageControllerWithFakeContent(fakePage);
+
+        var result = await pageController.Index("a-slug-that-does-not-exist");
+
+        TypeAssert.IsType<NotFoundResult>(result);
+    }
+
+    [TestMethod]
+    public async Task Index__ReturnsExpectedView()
+    {
+        var fakePage = new PageContent();
+        var pageController = CreatePageControllerWithFakeContent(fakePage);
+
+        var result = await pageController.Index("an-example-page-handle");
+
+        TypeAssert.IsType<ViewResult>(result);
+    }
+
+    [TestMethod]
+    public async Task Index__ProvidesPageContentAsViewModel()
+    {
+        var fakePage = new PageContent();
+        var pageController = CreatePageControllerWithFakeContent(fakePage);
+
+        var result = await pageController.Index("an-example-page-handle");
+
+        var viewResult = TypeAssert.IsType<ViewResult>(result);
+        Assert.AreSame(fakePage, viewResult.Model);
+    }
+
+    #endregion
+}

--- a/Dfe.SchoolAccount.Web/Constants/ContentTypeConstants.cs
+++ b/Dfe.SchoolAccount.Web/Constants/ContentTypeConstants.cs
@@ -5,5 +5,6 @@ public static class ContentTypeConstants
     public const string ErrorPage = "errorPage";
     public const string ExternalResource = "externalResource";
     public const string Hub = "hub";
+    public const string Page = "page";
     public const string SignpostingPage = "signpostingPage";
 }

--- a/Dfe.SchoolAccount.Web/Controllers/ErrorPageController.cs
+++ b/Dfe.SchoolAccount.Web/Controllers/ErrorPageController.cs
@@ -25,7 +25,7 @@ public sealed class ErrorPageController : Controller
 
         if (model == null) {
             this.logger.LogError($"Could not find error page with the handle '{handle}'.");
-            return this.NotFound(handle);
+            return this.NotFound();
         }
 
         var view = this.View("Index", model);

--- a/Dfe.SchoolAccount.Web/Controllers/PageController.cs
+++ b/Dfe.SchoolAccount.Web/Controllers/PageController.cs
@@ -1,0 +1,35 @@
+﻿namespace Dfe.SchoolAccount.Web.Controllers;
+
+using Dfe.SchoolAccount.Web.Services.Content;
+using Microsoft.AspNetCore.Mvc;
+
+public sealed class PageController : Controller
+{
+    private readonly ILogger<PageController> logger;
+    private readonly IPageContentFetcher pageContentFetcher;
+
+    public PageController(
+        ILogger<PageController> logger,
+        IPageContentFetcher pageContentFetcher)
+    {
+        this.logger = logger;
+        this.pageContentFetcher = pageContentFetcher;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Index(string slug)
+    {
+        this.logger.LogInformation($"Page '{slug}' was presented.");
+
+        var model = await this.pageContentFetcher.FetchPageContentAsync(slug);
+
+        if (model == null) {
+            this.logger.LogError($"Could not find page with the slug '{slug}'.");
+            return this.NotFound();
+        }
+
+        var view = this.View("Index", model);
+
+        return view;
+    }
+}

--- a/Dfe.SchoolAccount.Web/Models/Content/PageContent.cs
+++ b/Dfe.SchoolAccount.Web/Models/Content/PageContent.cs
@@ -1,0 +1,14 @@
+﻿namespace Dfe.SchoolAccount.Web.Models.Content;
+
+using Contentful.Core.Models;
+
+public sealed class PageContent : IContent
+{
+    public string Slug { get; set; } = null!;
+
+    public string Title { get; set; } = null!;
+
+    public string Summary { get; set; } = null!;
+
+    public Document? Body { get; set; }
+}

--- a/Dfe.SchoolAccount.Web/Program.cs
+++ b/Dfe.SchoolAccount.Web/Program.cs
@@ -87,6 +87,8 @@ builder.Services.AddContentful(builder.Configuration);
 builder.Services.AddTransient((IServiceProvider sp) => {
     var renderer = new HtmlRenderer();
     renderer.AddRenderer(new CustomHeadingRenderer(renderer.Renderers));
+    renderer.AddRenderer(new CustomListContentRenderer(renderer.Renderers));
+    renderer.AddRenderer(new CustomQuoteRenderer(renderer.Renderers));
     renderer.AddRenderer(new CardGroupModelRenderer(sp.GetRequiredService<IRazorViewEngine>(), sp.GetRequiredService<ITempDataProvider>(), sp) { Order = 10 });
     return renderer;
 });

--- a/Dfe.SchoolAccount.Web/Program.cs
+++ b/Dfe.SchoolAccount.Web/Program.cs
@@ -95,6 +95,7 @@ builder.Services.AddSingleton<IPersonaResolver, OrganisationTypePersonaResolver>
 builder.Services.AddSingleton<IHubContentFetcher, ContentfulHubContentFetcher>();
 builder.Services.AddSingleton<ISignpostingPageContentFetcher, ContentfulSignpostingPageContentFetcher>();
 builder.Services.AddSingleton<IErrorPageContentFetcher, ContentfulErrorPageContentFetcher>();
+builder.Services.AddSingleton<IPageContentFetcher, ContentfulPageContentFetcher>();
 
 builder.Services.AddSingleton<IContentModelTransformHandler<ExternalResourceContent, CardModel>, ExternalResourceContentToCardTransformHandler>();
 builder.Services.AddSingleton<IContentModelTransformHandler<SignpostingPageContent, CardModel>, SignpostingPageContentToCardTransformHandler>();
@@ -145,6 +146,12 @@ app.MapControllerRoute(
 app.MapControllerRoute(
     name: "default",
     pattern: "{controller}/{action=Index}/{id?}"
+);
+
+app.MapControllerRoute(
+    name: "page",
+    pattern: "{slug}",
+    defaults: new { controller = "Page", action = "Index" }
 );
 
 app.Run();

--- a/Dfe.SchoolAccount.Web/Services/Content/ContentfulPageContentFetcher.cs
+++ b/Dfe.SchoolAccount.Web/Services/Content/ContentfulPageContentFetcher.cs
@@ -1,0 +1,50 @@
+﻿namespace Dfe.SchoolAccount.Web.Services.Content;
+
+using System.Threading.Tasks;
+using Contentful.Core;
+using Contentful.Core.Search;
+using Dfe.SchoolAccount.Web.Constants;
+using Dfe.SchoolAccount.Web.Models.Content;
+
+/// <summary>
+/// A service which fetches general page content from a Contentful CDA.
+/// </summary>
+public sealed class ContentfulPageContentFetcher : IPageContentFetcher
+{
+    private readonly IContentfulClient contentfulClient;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ContentfulPageContentFetcher"/> class.
+    /// </summary>
+    /// <param name="contentfulClient">The contentful client.</param>
+    /// <exception cref="ArgumentNullException">
+    /// If <paramref name="contentfulClient"/> is <c>null</c>.
+    /// </exception>
+    public ContentfulPageContentFetcher(IContentfulClient contentfulClient)
+    {
+        if (contentfulClient == null) {
+            throw new ArgumentNullException(nameof(contentfulClient));
+        }
+
+        this.contentfulClient = contentfulClient;
+    }
+
+    /// <inheritdoc/>
+    public async Task<PageContent?> FetchPageContentAsync(string slug)
+    {
+        if (slug == null) {
+            throw new ArgumentNullException(nameof(slug));
+        }
+        if (slug == "") {
+            throw new ArgumentException("Cannot be an empty string.", nameof(slug));
+        }
+
+        var pageEntries = await this.contentfulClient.GetEntries(
+            QueryBuilder<PageContent>.New
+                .ContentTypeIs(ContentTypeConstants.Page)
+                .FieldEquals("fields.slug", slug)
+        );
+
+        return pageEntries.SingleOrDefault();
+    }
+}

--- a/Dfe.SchoolAccount.Web/Services/Content/IPageContentFetcher.cs
+++ b/Dfe.SchoolAccount.Web/Services/Content/IPageContentFetcher.cs
@@ -1,0 +1,24 @@
+﻿namespace Dfe.SchoolAccount.Web.Services.Content;
+
+using Dfe.SchoolAccount.Web.Models.Content;
+
+/// <summary>
+/// A service which fetches a general page of content.
+/// </summary>
+public interface IPageContentFetcher
+{
+    /// <summary>
+    /// Fetches a general page of content with the given slug.
+    /// </summary>
+    /// <param name="slug">Unique slug of the page.</param>
+    /// <returns>
+    /// An object with the page content when found; otherwise, a value of <c>null</c>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// If <paramref name="slug"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// If <paramref name="slug"/> is an empty string.
+    /// </exception>
+    Task<PageContent?> FetchPageContentAsync(string slug);
+}

--- a/Dfe.SchoolAccount.Web/Services/Rendering/CustomHeadingRenderer.cs
+++ b/Dfe.SchoolAccount.Web/Services/Rendering/CustomHeadingRenderer.cs
@@ -8,6 +8,9 @@ using Contentful.Core.Models;
 /// <summary>
 /// Renders headings starting at <c>&lt;h2&gt;</c> with appropriate classes added.
 /// </summary>
+/// <remarks>
+/// <para>This implementation is derived from https://github.com/contentful/contentful.net/blob/master/Contentful.Core/Models/Authoring.cs#L430.</para>
+/// </remarks>
 [ExcludeFromCodeCoverage]
 public sealed class CustomHeadingRenderer : IContentRenderer
 {

--- a/Dfe.SchoolAccount.Web/Services/Rendering/CustomListContentRenderer.cs
+++ b/Dfe.SchoolAccount.Web/Services/Rendering/CustomListContentRenderer.cs
@@ -1,0 +1,62 @@
+﻿namespace Dfe.SchoolAccount.Web.Services.Rendering;
+
+using Contentful.Core.Models;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+
+/// <summary>
+/// Renders list elements with appropriate classes added.
+/// </summary>
+/// <remarks>
+/// <para>This implementation is derived from https://github.com/contentful/contentful.net/blob/master/Contentful.Core/Models/Authoring.cs#L754.</para>
+/// </remarks>
+[ExcludeFromCodeCoverage]
+public sealed class CustomListContentRenderer : IContentRenderer
+{
+    private readonly ContentRendererCollection rendererCollection;
+
+    /// <summary>
+    /// Initializes a new ListContentRenderer.
+    /// </summary>
+    /// <param name="rendererCollection">The collection of renderer to use for sub-content.</param>
+    public CustomListContentRenderer(ContentRendererCollection rendererCollection)
+    {
+        this.rendererCollection = rendererCollection;
+    }
+
+    /// <inheritdoc/>
+    public int Order { get; set; }
+
+    /// <inheritdoc/>
+    public bool SupportsContent(IContent content)
+    {
+        return content is List;
+    }
+
+    /// <inheritdoc/>
+    public async Task<string> RenderAsync(IContent content)
+    {
+        var list = (List)content;
+
+        string listTagType = "ul";
+        string govukListClass = "govuk-list govuk-list--bullet govuk-list--spaced";
+
+        if (list.NodeType == "ordered-list") {
+            listTagType = "ol";
+            govukListClass = "govuk-list govuk-list--number";
+        }
+
+        var sb = new StringBuilder();
+
+        sb.Append($"<{listTagType} class=\"{govukListClass}\">");
+
+        foreach (var subContent in list.Content) {
+            var renderer = this.rendererCollection.GetRendererForContent(subContent);
+            sb.Append(await renderer.RenderAsync(subContent));
+        }
+
+        sb.Append($"</{listTagType}>");
+
+        return sb.ToString();
+    }
+}

--- a/Dfe.SchoolAccount.Web/Services/Rendering/CustomQuoteRenderer.cs
+++ b/Dfe.SchoolAccount.Web/Services/Rendering/CustomQuoteRenderer.cs
@@ -1,0 +1,55 @@
+﻿namespace Dfe.SchoolAccount.Web.Services.Rendering;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Threading.Tasks;
+using Contentful.Core.Models;
+
+/// <summary>
+/// Renders quotes with appropriate classes added.
+/// </summary>
+/// <remarks>
+/// <para>This implementation is derived from https://github.com/contentful/contentful.net/blob/master/Contentful.Core/Models/Authoring.cs#L887.</para>
+/// </remarks>
+[ExcludeFromCodeCoverage]
+public sealed class CustomQuoteRenderer : IContentRenderer
+{
+    private readonly ContentRendererCollection rendererCollection;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CustomQuoteRenderer"/> class.
+    /// </summary>
+    /// <param name="rendererCollection">The collection of renderer to use for sub-content.</param>
+    public CustomQuoteRenderer(ContentRendererCollection rendererCollection)
+    {
+        this.rendererCollection = rendererCollection;
+    }
+
+    /// <inheritdoc/>
+    public int Order { get; set; }
+
+    /// <inheritdoc/>
+    public bool SupportsContent(IContent content)
+    {
+        return content is Quote;
+    }
+
+    /// <inheritdoc/>
+    public async Task<string> RenderAsync(IContent content)
+    {
+        var quote = (Quote)content;
+
+        var sb = new StringBuilder();
+
+        sb.Append($"<blockquote class=\"govuk-inset-text\">");
+
+        foreach (var subContent in quote.Content) {
+            var renderer = this.rendererCollection.GetRendererForContent(subContent);
+            sb.Append(await renderer.RenderAsync(subContent));
+        }
+
+        sb.Append($"</blockquote>");
+
+        return sb.ToString();
+    }
+}

--- a/Dfe.SchoolAccount.Web/Views/Page/Index.cshtml
+++ b/Dfe.SchoolAccount.Web/Views/Page/Index.cshtml
@@ -1,0 +1,15 @@
+﻿@using Dfe.SchoolAccount.Web.Models.Content;
+
+@model PageContent
+
+@inject IViewLocalizer ViewLocalizer
+
+@{
+    ViewData["Title"] = Model.Title;
+}
+
+<h1 class="govuk-heading-xl">
+    @ViewData["Title"]
+</h1>
+
+<contentful-rich-text document="@Model.Body"></contentful-rich-text>


### PR DESCRIPTION
This will allow for the creation of general content pages such as "Privacy policy", etc.

## Notes
- This PR also overrides the rendering of `<ul>`, `<ol>` and `<blockquote>` elements when rendering rich text content using the Contentful SDK so that GDS design system classes can be added to them.