### PR TITLE
Add feature to resolve hyperlinks to content entries

### DIFF
--- a/Dfe.SchoolAccount.Web.Tests/Services/Content/CustomContentTypeResolverTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Services/Content/CustomContentTypeResolverTests.cs
@@ -21,6 +21,7 @@ public sealed class CustomContentTypeResolverTests
 
     [DataRow(ContentTypeConstants.ExternalResource, typeof(ExternalResourceContent))]
     [DataRow(ContentTypeConstants.SignpostingPage, typeof(SignpostingPageContent))]
+    [DataRow(ContentTypeConstants.Page, typeof(PageContent))]
     [DataTestMethod]
     public void Resolve__ReturnsExpectedTypeForGivenContentTypeId(string contentTypeId, Type expectedContentType)
     {

--- a/Dfe.SchoolAccount.Web.Tests/Services/ContentHyperlinks/Handlers/ExternalResourceContentHyperlinkResolutionHandlerTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Services/ContentHyperlinks/Handlers/ExternalResourceContentHyperlinkResolutionHandlerTests.cs
@@ -1,0 +1,28 @@
+﻿namespace Dfe.SchoolAccount.Web.Tests.Services.ContentHyperlinks.Handlers;
+
+using Dfe.SchoolAccount.Web.Models.Content;
+using Dfe.SchoolAccount.Web.Services.ContentHyperlinks.Handlers;
+
+[TestClass]
+public sealed class ExternalResourceContentHyperlinkResolutionHandlerTests
+{
+    #region ContentHyperlink? ResolveContentHyperlink(ExternalResourceContent)
+
+    [TestMethod]
+    public void ResolveContentHyperlink__ReturnsExpectedContentHyperlink()
+    {
+        var fakeContent = new ExternalResourceContent {
+            Title = "Test external resource",
+            LinkUrl = "https://example.localhost/test-external-resource",
+        };
+
+        var externalResourceContentHyperlinkResolutionHandler = new ExternalResourceContentHyperlinkResolutionHandler();
+
+        var contentHyperlink = externalResourceContentHyperlinkResolutionHandler.ResolveContentHyperlink(fakeContent)!;
+
+        Assert.AreEqual("Test external resource", contentHyperlink.Text);
+        Assert.AreEqual("https://example.localhost/test-external-resource", contentHyperlink.Url);
+    }
+
+    #endregion
+}

--- a/Dfe.SchoolAccount.Web.Tests/Services/ContentHyperlinks/Handlers/PageContentHyperlinkResolutionHandlerTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Services/ContentHyperlinks/Handlers/PageContentHyperlinkResolutionHandlerTests.cs
@@ -1,0 +1,28 @@
+﻿namespace Dfe.SchoolAccount.Web.Tests.Services.ContentHyperlinks.Handlers;
+
+using Dfe.SchoolAccount.Web.Models.Content;
+using Dfe.SchoolAccount.Web.Services.ContentHyperlinks.Handlers;
+
+[TestClass]
+public sealed class PageContentHyperlinkResolutionHandlerTests
+{
+    #region ContentHyperlink? ResolveContentHyperlink(PageContent)
+
+    [TestMethod]
+    public void ResolveContentHyperlink__ReturnsExpectedContentHyperlink()
+    {
+        var fakeContent = new PageContent {
+            Title = "An example page",
+            Slug = "example-slug"
+        };
+
+        var pageContentHyperlinkResolutionHandler = new PageContentHyperlinkResolutionHandler();
+
+        var contentHyperlink = pageContentHyperlinkResolutionHandler.ResolveContentHyperlink(fakeContent)!;
+
+        Assert.AreEqual("An example page", contentHyperlink.Text);
+        Assert.AreEqual("/example-slug", contentHyperlink.Url);
+    }
+
+    #endregion
+}

--- a/Dfe.SchoolAccount.Web.Tests/Services/ContentHyperlinks/Handlers/SignpostingPageContentHyperlinkResolutionHandlerTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Services/ContentHyperlinks/Handlers/SignpostingPageContentHyperlinkResolutionHandlerTests.cs
@@ -1,0 +1,28 @@
+﻿namespace Dfe.SchoolAccount.Web.Tests.Services.ContentHyperlinks.Handlers;
+
+using Dfe.SchoolAccount.Web.Models.Content;
+using Dfe.SchoolAccount.Web.Services.ContentHyperlinks.Handlers;
+
+[TestClass]
+public sealed class SignpostingSignpostingPageContentHyperlinkResolutionHandlerTests
+{
+    #region ContentHyperlink? ResolveContentHyperlink(SignpostingPageContent)
+
+    [TestMethod]
+    public void ResolveContentHyperlink__ReturnsExpectedContentHyperlink()
+    {
+        var fakeContent = new SignpostingPageContent {
+            Title = "An example signposting page",
+            Slug = "example-slug"
+        };
+
+        var signpostingPageContentHyperlinkResolutionHandler = new SignpostingPageContentHyperlinkResolutionHandler();
+
+        var contentHyperlink = signpostingPageContentHyperlinkResolutionHandler.ResolveContentHyperlink(fakeContent)!;
+
+        Assert.AreEqual("An example signposting page", contentHyperlink.Text);
+        Assert.AreEqual("/signposting/example-slug", contentHyperlink.Url);
+    }
+
+    #endregion
+}

--- a/Dfe.SchoolAccount.Web.Tests/Services/ContentHyperlinks/RegisteredServicesContentHyperlinkResolverTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Services/ContentHyperlinks/RegisteredServicesContentHyperlinkResolverTests.cs
@@ -1,0 +1,73 @@
+﻿namespace Dfe.SchoolAccount.Web.Tests.Services.ContentHyperlinks;
+
+using Dfe.SchoolAccount.Web.Models.Content;
+using Dfe.SchoolAccount.Web.Services.ContentHyperlinks;
+using Moq;
+
+[TestClass]
+public sealed class RegisteredServicesContentHyperlinkResolverTests
+{
+    #region Constructor(IServiceProvider)
+
+    [TestMethod]
+    public void Constructor__ThrowsArgumentNullException__WhenServiceProviderArgumentIsNull()
+    {
+        var act = () => {
+            _ = new RegisteredServicesContentHyperlinkResolver(null!);
+        };
+
+        Assert.ThrowsException<ArgumentNullException>(act);
+    }
+
+    #endregion
+
+    #region ContentHyperlink? ResolveContentHyperlink(object)
+
+    [TestMethod]
+    public void ResolveContentHyperlink__ThrowsArgumentNullException__WhenContentArgumentIsNull()
+    {
+        var serviceProvider = new Mock<IServiceProvider>();
+
+        var registeredServicesContentHyperlinkResolver = new RegisteredServicesContentHyperlinkResolver(serviceProvider.Object);
+
+        var act = () => {
+            _ = registeredServicesContentHyperlinkResolver.ResolveContentHyperlink(null!);
+        };
+
+        var exception = Assert.ThrowsException<ArgumentNullException>(act);
+        Assert.AreEqual("content", exception.ParamName);
+    }
+
+    [TestMethod]
+    public void ResolveContentHyperlink__ReturnsNull__WhenHandlerIsNotRegistered()
+    {
+        var serviceProvider = new Mock<IServiceProvider>();
+
+        var registeredServicesContentHyperlinkResolver = new RegisteredServicesContentHyperlinkResolver(serviceProvider.Object);
+        var fakeContent = new ExternalResourceContent();
+
+        var contentHyperlink = registeredServicesContentHyperlinkResolver.ResolveContentHyperlink(fakeContent);
+
+        Assert.IsNull(contentHyperlink);
+    }
+
+    [TestMethod]
+    public void ResolveContentHyperlink__InvokesExpectedHandler()
+    {
+        var mockHandler = new Mock<IContentHyperlinkResolutionHandler<ExternalResourceContent>>();
+
+        var serviceProvider = new Mock<IServiceProvider>();
+        var expectedServiceType = typeof(IContentHyperlinkResolutionHandler<ExternalResourceContent>);
+        serviceProvider.Setup(mock => mock.GetService(It.Is<Type>(serviceType => serviceType == expectedServiceType)))
+            .Returns(mockHandler.Object);
+
+        var registeredServicesContentHyperlinkResolver = new RegisteredServicesContentHyperlinkResolver(serviceProvider.Object);
+        var fakeContent = new ExternalResourceContent();
+
+        _ = registeredServicesContentHyperlinkResolver.ResolveContentHyperlink(fakeContent);
+
+        mockHandler.Verify(mock => mock.ResolveContentHyperlink(It.Is<ExternalResourceContent>(content => content == fakeContent)));
+    }
+
+    #endregion
+}

--- a/Dfe.SchoolAccount.Web.Tests/Services/ContentTransformers/Cards/SignpostingPageContentToCardTransformHandlerTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Services/ContentTransformers/Cards/SignpostingPageContentToCardTransformHandlerTests.cs
@@ -1,7 +1,9 @@
 ﻿namespace Dfe.SchoolAccount.Web.Tests.Services.ContentTransformers.Cards;
 
 using Dfe.SchoolAccount.Web.Models.Content;
+using Dfe.SchoolAccount.Web.Services.ContentHyperlinks;
 using Dfe.SchoolAccount.Web.Services.ContentTransformers.Cards;
+using Moq;
 
 [TestClass]
 public sealed class SignpostingPageContentToCardTransformHandlerTests
@@ -17,7 +19,11 @@ public sealed class SignpostingPageContentToCardTransformHandlerTests
             Summary = "Summary of the signposting page.",
         };
 
-        var signpostingPageContentToCardTransformHandler = new SignpostingPageContentToCardTransformHandler();
+        var contentHyperlinkResolverMock = new Mock<IContentHyperlinkResolver>();
+        contentHyperlinkResolverMock.Setup(mock => mock.ResolveContentHyperlink(It.Is<SignpostingPageContent>(param => param == signpostingPageContent)))
+            .Returns(new ContentHyperlink { Url = "/signposting/example-signposting-page" });
+
+        var signpostingPageContentToCardTransformHandler = new SignpostingPageContentToCardTransformHandler(contentHyperlinkResolverMock.Object);
 
         var cardModel = signpostingPageContentToCardTransformHandler.TransformContentToModel(signpostingPageContent);
 

--- a/Dfe.SchoolAccount.Web.Tests/Services/ContentTransformers/RegisteredServicesContentModelTransformerTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Services/ContentTransformers/RegisteredServicesContentModelTransformerTests.cs
@@ -27,7 +27,6 @@ public sealed class RegisteredServicesContentModelTransformerTests
     public void TransformContentToModel_TTargetModel__ThrowsInvalidOperationException__WhenTransformHandlerIsNotRegistered()
     {
         var serviceProvider = new Mock<IServiceProvider>();
-        serviceProvider.Setup(mock => mock.GetService(It.IsAny<Type>()));
 
         var registeredServicesContentModelTransformer = new RegisteredServicesContentModelTransformer(serviceProvider.Object);
         var fakeCardContent = new ExternalResourceContent();

--- a/Dfe.SchoolAccount.Web.Tests/Services/ContentTransformers/RegisteredServicesContentModelTransformerTests.cs
+++ b/Dfe.SchoolAccount.Web.Tests/Services/ContentTransformers/RegisteredServicesContentModelTransformerTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Dfe.SchoolAccount.Web.Tests.Services.ContentTransformers.Cards;
+﻿namespace Dfe.SchoolAccount.Web.Tests.Services.ContentTransformers;
 
 using Dfe.SchoolAccount.Web.Models.Content;
 using Dfe.SchoolAccount.Web.Services.ContentTransformers;

--- a/Dfe.SchoolAccount.Web/Models/Content/CardModel.cs
+++ b/Dfe.SchoolAccount.Web/Models/Content/CardModel.cs
@@ -6,5 +6,5 @@ public sealed class CardModel
 
     public string Summary { get; set; } = null!;
 
-    public string LinkUrl { get; set; } = null!;
+    public string? LinkUrl { get; set; }
 }

--- a/Dfe.SchoolAccount.Web/Program.cs
+++ b/Dfe.SchoolAccount.Web/Program.cs
@@ -9,6 +9,7 @@ using Dfe.SchoolAccount.Web.Constants;
 using Dfe.SchoolAccount.Web.Models.Content;
 using Dfe.SchoolAccount.Web.Services.Content;
 using Dfe.SchoolAccount.Web.Services.ContentHyperlinks;
+using Dfe.SchoolAccount.Web.Services.ContentHyperlinks.Handlers;
 using Dfe.SchoolAccount.Web.Services.ContentTransformers;
 using Dfe.SchoolAccount.Web.Services.ContentTransformers.Cards;
 using Dfe.SchoolAccount.Web.Services.Personas;
@@ -105,6 +106,9 @@ builder.Services.AddSingleton<IContentModelTransformHandler<ExternalResourceCont
 builder.Services.AddSingleton<IContentModelTransformHandler<SignpostingPageContent, CardModel>, SignpostingPageContentToCardTransformHandler>();
 builder.Services.AddSingleton<IContentModelTransformer, RegisteredServicesContentModelTransformer>();
 
+builder.Services.AddSingleton<IContentHyperlinkResolutionHandler<PageContent>, PageContentHyperlinkResolutionHandler>();
+builder.Services.AddSingleton<IContentHyperlinkResolutionHandler<ExternalResourceContent>, ExternalResourceContentHyperlinkResolutionHandler>();
+builder.Services.AddSingleton<IContentHyperlinkResolutionHandler<SignpostingPageContent>, SignpostingPageContentHyperlinkResolutionHandler>();
 builder.Services.AddSingleton<IContentHyperlinkResolver, RegisteredServicesContentHyperlinkResolver>();
 
 builder.Services.AddControllersWithViews()

--- a/Dfe.SchoolAccount.Web/Program.cs
+++ b/Dfe.SchoolAccount.Web/Program.cs
@@ -91,6 +91,7 @@ builder.Services.AddTransient((IServiceProvider sp) => {
     renderer.AddRenderer(new CustomListContentRenderer(renderer.Renderers));
     renderer.AddRenderer(new CustomQuoteRenderer(renderer.Renderers));
     renderer.AddRenderer(new CardGroupModelRenderer(sp.GetRequiredService<IRazorViewEngine>(), sp.GetRequiredService<ITempDataProvider>(), sp) { Order = 10 });
+    renderer.AddRenderer(new ContentLinkRenderer(sp.GetRequiredService<IContentHyperlinkResolver>(), renderer.Renderers));
     return renderer;
 });
 

--- a/Dfe.SchoolAccount.Web/Program.cs
+++ b/Dfe.SchoolAccount.Web/Program.cs
@@ -8,6 +8,7 @@ using Dfe.SchoolAccount.Web.Authorization;
 using Dfe.SchoolAccount.Web.Constants;
 using Dfe.SchoolAccount.Web.Models.Content;
 using Dfe.SchoolAccount.Web.Services.Content;
+using Dfe.SchoolAccount.Web.Services.ContentHyperlinks;
 using Dfe.SchoolAccount.Web.Services.ContentTransformers;
 using Dfe.SchoolAccount.Web.Services.ContentTransformers.Cards;
 using Dfe.SchoolAccount.Web.Services.Personas;
@@ -102,6 +103,8 @@ builder.Services.AddSingleton<IPageContentFetcher, ContentfulPageContentFetcher>
 builder.Services.AddSingleton<IContentModelTransformHandler<ExternalResourceContent, CardModel>, ExternalResourceContentToCardTransformHandler>();
 builder.Services.AddSingleton<IContentModelTransformHandler<SignpostingPageContent, CardModel>, SignpostingPageContentToCardTransformHandler>();
 builder.Services.AddSingleton<IContentModelTransformer, RegisteredServicesContentModelTransformer>();
+
+builder.Services.AddSingleton<IContentHyperlinkResolver, RegisteredServicesContentHyperlinkResolver>();
 
 builder.Services.AddControllersWithViews()
     .AddMvcLocalization(options => {

--- a/Dfe.SchoolAccount.Web/Services/Content/CustomContentTypeResolver.cs
+++ b/Dfe.SchoolAccount.Web/Services/Content/CustomContentTypeResolver.cs
@@ -10,6 +10,7 @@ public sealed class CustomContentTypeResolver : IContentTypeResolver
     private static readonly IReadOnlyDictionary<string, Type> s_ContentTypeIdToTypeMap = new Dictionary<string, Type> {
         { ContentTypeConstants.ExternalResource, typeof(ExternalResourceContent) },
         { ContentTypeConstants.SignpostingPage, typeof(SignpostingPageContent) },
+        { ContentTypeConstants.Page, typeof(PageContent) },
     };
 
     /// <inheritdoc/>

--- a/Dfe.SchoolAccount.Web/Services/ContentHyperlinks/ContentHyperlink.cs
+++ b/Dfe.SchoolAccount.Web/Services/ContentHyperlinks/ContentHyperlink.cs
@@ -1,0 +1,19 @@
+﻿namespace Dfe.SchoolAccount.Web.Services.ContentHyperlinks;
+
+/// <summary>
+/// Represents a link to some content.
+/// </summary>
+/// <seealso cref="IContentHyperlinkResolver"/>
+/// <seealso cref="IContentHyperlinkResolutionHandler{TContent}"/>
+public sealed class ContentHyperlink
+{
+    /// <summary>
+    /// Gets or sets the URL of the link.
+    /// </summary>
+    public string Url { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the text of the link.
+    /// </summary>
+    public string Text { get; set; } = null!;
+}

--- a/Dfe.SchoolAccount.Web/Services/ContentHyperlinks/Handlers/ExternalResourceContentHyperlinkResolutionHandler.cs
+++ b/Dfe.SchoolAccount.Web/Services/ContentHyperlinks/Handlers/ExternalResourceContentHyperlinkResolutionHandler.cs
@@ -1,0 +1,18 @@
+﻿namespace Dfe.SchoolAccount.Web.Services.ContentHyperlinks.Handlers;
+
+using Dfe.SchoolAccount.Web.Models.Content;
+
+/// <summary>
+/// Resolves hyperlinks for <see cref="ExternalResourceContent"/> references.
+/// </summary>
+public sealed class ExternalResourceContentHyperlinkResolutionHandler : IContentHyperlinkResolutionHandler<ExternalResourceContent>
+{
+    /// <inheritdoc/>
+    public ContentHyperlink? ResolveContentHyperlink(ExternalResourceContent content)
+    {
+        return new ContentHyperlink {
+            Url = content.LinkUrl,
+            Text = content.Title,
+        };
+    }
+}

--- a/Dfe.SchoolAccount.Web/Services/ContentHyperlinks/Handlers/PageContentHyperlinkResolutionHandler.cs
+++ b/Dfe.SchoolAccount.Web/Services/ContentHyperlinks/Handlers/PageContentHyperlinkResolutionHandler.cs
@@ -1,0 +1,18 @@
+﻿namespace Dfe.SchoolAccount.Web.Services.ContentHyperlinks.Handlers;
+
+using Dfe.SchoolAccount.Web.Models.Content;
+
+/// <summary>
+/// Resolves hyperlinks for <see cref="SignpostingPageContent"/> references.
+/// </summary>
+public sealed class SignpostingPageContentHyperlinkResolutionHandler : IContentHyperlinkResolutionHandler<SignpostingPageContent>
+{
+    /// <inheritdoc/>
+    public ContentHyperlink? ResolveContentHyperlink(SignpostingPageContent content)
+    {
+        return new ContentHyperlink {
+            Url = $"/signposting/{content.Slug}",
+            Text = content.Title,
+        };
+    }
+}

--- a/Dfe.SchoolAccount.Web/Services/ContentHyperlinks/Handlers/SignpostingPageContentHyperlinkResolutionHandler.cs
+++ b/Dfe.SchoolAccount.Web/Services/ContentHyperlinks/Handlers/SignpostingPageContentHyperlinkResolutionHandler.cs
@@ -1,0 +1,18 @@
+﻿namespace Dfe.SchoolAccount.Web.Services.ContentHyperlinks.Handlers;
+
+using Dfe.SchoolAccount.Web.Models.Content;
+
+/// <summary>
+/// Resolves hyperlinks for <see cref="PageContent"/> references.
+/// </summary>
+public sealed class PageContentHyperlinkResolutionHandler : IContentHyperlinkResolutionHandler<PageContent>
+{
+    /// <inheritdoc/>
+    public ContentHyperlink? ResolveContentHyperlink(PageContent content)
+    {
+        return new ContentHyperlink {
+            Url = $"/{content.Slug}",
+            Text = content.Title,
+        };
+    }
+}

--- a/Dfe.SchoolAccount.Web/Services/ContentHyperlinks/IContentHyperlinkResolutionHandler{TContent}.cs
+++ b/Dfe.SchoolAccount.Web/Services/ContentHyperlinks/IContentHyperlinkResolutionHandler{TContent}.cs
@@ -1,0 +1,20 @@
+﻿namespace Dfe.SchoolAccount.Web.Services.ContentHyperlinks;
+
+using Contentful.Core.Models;
+
+/// <summary>
+/// Handles URL and default link text resolution for a particular type of content.
+/// </summary>
+/// <typeparam name="TContent">Type of content.</typeparam>
+public interface IContentHyperlinkResolutionHandler<TContent>
+    where TContent : IContent
+{
+    /// <summary>
+    /// Resolves a link to some content.
+    /// </summary>
+    /// <param name="content">The content.</param>
+    /// <returns>
+    /// A link to the given content when applicable; otherwise, a value of <c>null</c>.
+    /// </returns>
+    ContentHyperlink? ResolveContentHyperlink(TContent content);
+}

--- a/Dfe.SchoolAccount.Web/Services/ContentHyperlinks/IContentHyperlinkResolver.cs
+++ b/Dfe.SchoolAccount.Web/Services/ContentHyperlinks/IContentHyperlinkResolver.cs
@@ -1,0 +1,19 @@
+﻿namespace Dfe.SchoolAccount.Web.Services.ContentHyperlinks;
+
+/// <summary>
+/// A service that resolves the URL and default link text for content.
+/// </summary>
+public interface IContentHyperlinkResolver
+{
+    /// <summary>
+    /// Resolves a link to some content.
+    /// </summary>
+    /// <param name="content">The content.</param>
+    /// <returns>
+    /// A link to the given content when applicable; otherwise, a value of <c>null</c>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// If <paramref name="content"/> is <c>null</c>.
+    /// </exception>
+    ContentHyperlink? ResolveContentHyperlink(object content);
+}

--- a/Dfe.SchoolAccount.Web/Services/ContentHyperlinks/RegisteredServicesContentHyperlinkResolver.cs
+++ b/Dfe.SchoolAccount.Web/Services/ContentHyperlinks/RegisteredServicesContentHyperlinkResolver.cs
@@ -1,0 +1,58 @@
+﻿namespace Dfe.SchoolAccount.Web.Services.ContentHyperlinks;
+
+using System.Reflection;
+using Contentful.Core.Models;
+
+/// <summary>
+/// A service which resolves a <see cref="IContentHyperlinkResolutionHandler{TContent}"/>
+/// in order to transform content to a different type of model.
+/// </summary>
+public sealed class RegisteredServicesContentHyperlinkResolver : IContentHyperlinkResolver
+{
+    private readonly IServiceProvider serviceProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RegisteredServicesContentHyperlinkResolver"/> class.
+    /// </summary>
+    /// <param name="serviceProvider">Service provider in order to resolve hyperlink resolution handlers.</param>
+    /// <exception cref="ArgumentNullException">
+    /// If <paramref name="serviceProvider"/> is <c>null</c>.
+    /// </exception>
+    public RegisteredServicesContentHyperlinkResolver(IServiceProvider serviceProvider)
+    {
+        if (serviceProvider == null) {
+            throw new ArgumentNullException(nameof(serviceProvider));
+        }
+
+        this.serviceProvider = serviceProvider;
+    }
+
+    /// <inheritdoc/>
+    public ContentHyperlink? ResolveContentHyperlink(object content)
+    {
+        if (content == null) {
+            throw new ArgumentNullException(nameof(content));
+        }
+
+        var hyperlinkResolutionHandlerType = GetHyperlinkResolutionHandlerType(content.GetType());
+        var hyperlinkResolutionHandler = this.serviceProvider.GetService(hyperlinkResolutionHandlerType);
+        if (hyperlinkResolutionHandler == null) {
+            return null;
+        }
+
+        var methodInfo = GetResolveContentHyperlinkMethod(hyperlinkResolutionHandlerType);
+        return (ContentHyperlink?)methodInfo.Invoke(hyperlinkResolutionHandler, new object[] { content })!;
+    }
+
+    private static Type GetHyperlinkResolutionHandlerType(Type contentType)
+    {
+        var handlerGenericType = typeof(IContentHyperlinkResolutionHandler<>);
+        return handlerGenericType.MakeGenericType(contentType);
+    }
+
+    private static MethodInfo GetResolveContentHyperlinkMethod(Type hyperlinkResolutionHandlerType)
+    {
+        string methodName = nameof(IContentHyperlinkResolutionHandler<IContent>.ResolveContentHyperlink);
+        return hyperlinkResolutionHandlerType?.GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)!;
+    }
+}

--- a/Dfe.SchoolAccount.Web/Services/ContentTransformers/Cards/SignpostingPageContentToCardTransformHandler.cs
+++ b/Dfe.SchoolAccount.Web/Services/ContentTransformers/Cards/SignpostingPageContentToCardTransformHandler.cs
@@ -1,16 +1,30 @@
 ﻿namespace Dfe.SchoolAccount.Web.Services.ContentTransformers.Cards;
 
 using Dfe.SchoolAccount.Web.Models.Content;
+using Dfe.SchoolAccount.Web.Services.ContentHyperlinks;
 
 public sealed class SignpostingPageContentToCardTransformHandler : IContentModelTransformHandler<SignpostingPageContent, CardModel>
 {
+    private readonly IContentHyperlinkResolver contentHyperlinkResolver;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SignpostingPageContentToCardTransformHandler"/> class.
+    /// </summary>
+    /// <param name="contentHyperlinkResolver">A service to resolve hyperlinks from content references.</param>
+    public SignpostingPageContentToCardTransformHandler(IContentHyperlinkResolver contentHyperlinkResolver)
+    {
+        this.contentHyperlinkResolver = contentHyperlinkResolver;
+    }
+
     /// <inheritdoc/>
     public CardModel TransformContentToModel(SignpostingPageContent content)
     {
+        var contentHyperlink = this.contentHyperlinkResolver.ResolveContentHyperlink(content);
+
         return new CardModel {
             Heading = content.Title,
             Summary = content.Summary,
-            LinkUrl = $"/signposting/{content.Slug}",
+            LinkUrl = contentHyperlink?.Url,
         };
     }
 }

--- a/Dfe.SchoolAccount.Web/Services/Rendering/ContentLinkRenderer.cs
+++ b/Dfe.SchoolAccount.Web/Services/Rendering/ContentLinkRenderer.cs
@@ -32,7 +32,7 @@ public sealed class ContentLinkRenderer : IContentRenderer
     /// <inheritdoc/>
     public bool SupportsContent(IContent content)
     {
-        return content is EntryStructure entryStructure && entryStructure.Data is EntryStructureData && entryStructure.NodeType == "entry-hyperlink";
+        return content is EntryStructure entryStructure && entryStructure.NodeType == "entry-hyperlink";
     }
 
     /// <inheritdoc/>

--- a/Dfe.SchoolAccount.Web/Services/Rendering/ContentLinkRenderer.cs
+++ b/Dfe.SchoolAccount.Web/Services/Rendering/ContentLinkRenderer.cs
@@ -1,0 +1,67 @@
+﻿namespace Dfe.SchoolAccount.Web.Services.Rendering;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Threading.Tasks;
+using Contentful.Core.Models;
+using Dfe.SchoolAccount.Web.Services.ContentHyperlinks;
+
+/// <summary>
+/// Renders hyperlinks to content.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class ContentLinkRenderer : IContentRenderer
+{
+    private readonly IContentHyperlinkResolver contentHyperlinkResolver;
+    private readonly ContentRendererCollection rendererCollection;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ContentLinkRenderer"/> class.
+    /// </summary>
+    /// <param name="contentHyperlinkResolver">A service to resolve hyperlinks from content references.</param>
+    /// <param name="rendererCollection">The collection of renderer to use for sub-content.</param>
+    public ContentLinkRenderer(IContentHyperlinkResolver contentHyperlinkResolver, ContentRendererCollection rendererCollection)
+    {
+        this.contentHyperlinkResolver = contentHyperlinkResolver;
+        this.rendererCollection = rendererCollection;
+    }
+
+    /// <inheritdoc/>
+    public int Order { get; set; }
+
+    /// <inheritdoc/>
+    public bool SupportsContent(IContent content)
+    {
+        return content is EntryStructure entryStructure && entryStructure.Data is EntryStructureData && entryStructure.NodeType == "entry-hyperlink";
+    }
+
+    /// <inheritdoc/>
+    public async Task<string> RenderAsync(IContent content)
+    {
+        var entryStructure = (EntryStructure)content;
+
+        var contentHyperlink = this.contentHyperlinkResolver.ResolveContentHyperlink(entryStructure.Data.Target);
+        if (contentHyperlink == null) {
+            return "[missing link]";
+        }
+
+        string innerContent = await this.RenderInnerContent(entryStructure);
+        if (string.IsNullOrWhiteSpace(innerContent)) {
+            innerContent = contentHyperlink.Text;
+        }
+
+        return $"<a href=\"{contentHyperlink.Url}\">{innerContent}</a>";
+    }
+
+    private async Task<string> RenderInnerContent(EntryStructure entryStructure)
+    {
+        var sb = new StringBuilder();
+
+        foreach (var subContent in entryStructure.Content) {
+            var renderer = this.rendererCollection.GetRendererForContent(subContent);
+            sb.Append(await renderer.RenderAsync(subContent));
+        }
+
+        return sb.ToString();
+    }
+}

--- a/Dfe.SchoolAccount.Web/Views/Shared/Partials/_Cards.cshtml
+++ b/Dfe.SchoolAccount.Web/Views/Shared/Partials/_Cards.cshtml
@@ -12,7 +12,14 @@
             <div class="govuk-grid-column-one-third card-container">
                 <section class="app-card" aria-describedby="@cardSummaryId">
                     @Html.Raw($"<h{ Model.HeadingLevel } class=\"app-card__title govuk-heading-m\">")
+                    @if (!string.IsNullOrEmpty(card.LinkUrl))
+                    {
                         <a class="app-card__link govuk-link" href="@card.LinkUrl">@card.Heading</a>
+                    }
+                    else
+                    {
+                        @card.Heading
+                    }
                     @Html.Raw($"</h{ Model.HeadingLevel }>")
                     <div class="app-card__summary" id="@cardSummaryId">
                         @{


### PR DESCRIPTION
Add mechanism to resolve hyperlinks to referenced content entries which is then used when rendering links within rich text fields and also when rendering signposting page cards.

## How to test
- Verify that signposting cards still link to their associated signposting pages.
- Verify that hyperlinks in rich text fields link to their associated pages.

## Notes
- This mechanism is similar to the transform handler mechanism.