### PR TITLE
Responsive design fixes

### DIFF
--- a/Dfe.SchoolAccount.Web/Frontend/scss/components/header.scss
+++ b/Dfe.SchoolAccount.Web/Frontend/scss/components/header.scss
@@ -114,7 +114,7 @@
     padding-right: 0;
 
     @media (max-width: 61.865em) {
-      max-width: 220px;
+      margin-top: 10px;
     }
 
     @media (min-width: 40.0625em) {

--- a/Dfe.SchoolAccount.Web/Frontend/scss/main.scss
+++ b/Dfe.SchoolAccount.Web/Frontend/scss/main.scss
@@ -9,4 +9,11 @@
 /* DfE frontend utilises a 1200px max-width as opposed to GOVUK's 960px */
 .govuk-width-container {
   max-width: 1200px;
+
+  @media (min-width: 1280px) {
+    margin-right: auto;
+    margin-left: auto
+  }
+
+  @include dfe-width-container;
 }

--- a/Dfe.SchoolAccount.Web/Frontend/scss/main.scss
+++ b/Dfe.SchoolAccount.Web/Frontend/scss/main.scss
@@ -10,10 +10,5 @@
 .govuk-width-container {
   max-width: 1200px;
 
-  @media (min-width: 1280px) {
-    margin-right: auto;
-    margin-left: auto
-  }
-
   @include dfe-width-container;
 }

--- a/Dfe.SchoolAccount.Web/Views/Shared/_Layout.cshtml
+++ b/Dfe.SchoolAccount.Web/Views/Shared/_Layout.cshtml
@@ -52,7 +52,7 @@
 
     @await Html.PartialAsync("Partials/_DfEHeaderPartial")
 
-    <div class="govuk-width-container @ViewBag.ContainerClasses">
+    <div class="govuk-width-container dfe-width-container @ViewBag.ContainerClasses">
         <govuk-phase-banner>
             <govuk-phase-banner-tag>Beta</govuk-phase-banner-tag>
             This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.


### PR DESCRIPTION
- Adjusted service name to better use the width of the banner at smaller viewports (thanks to @kruncher!)
- Fix an issue where at certain viewports (between 960px and 1200px), the padding surrounding `govuk-width-container` wouldn't appear, causing a visual disparity on the site